### PR TITLE
Change command executors from singleton objects to instantiated class

### DIFF
--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/GearyCommands.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/GearyCommands.kt
@@ -10,7 +10,7 @@ import com.mineinabyss.idofront.messaging.info
 import com.mineinabyss.idofront.plugin.getService
 
 @ExperimentalCommandDSL
-internal object GearyCommands : IdofrontCommandExecutor() {
+internal class GearyCommands : IdofrontCommandExecutor() {
     override val commands = commands(geary) {
         "geary" {
             "components"{

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/GearyPlugin.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/GearyPlugin.kt
@@ -22,7 +22,8 @@ public class GearyPlugin : JavaPlugin() {
 
         registerService<Engine>(SpigotEngine().apply { start() })
 
-        GearyCommands
+        // Register commands.
+        GearyCommands()
 
         registerEvents(
             PlayerJoinLeaveListener,


### PR DESCRIPTION
This prevents the executors from being registered for a command before the plugin has been enabled.