### PR TITLE
Bugfixes since last update, startup loading system

### DIFF
--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/GearyPlugin.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/GearyPlugin.kt
@@ -7,12 +7,13 @@ import com.mineinabyss.geary.ecs.systems.ExpiringComponentSystem
 import com.mineinabyss.geary.ecs.systems.PassiveActionsSystem
 import com.mineinabyss.geary.minecraft.access.BukkitEntityAccess
 import com.mineinabyss.geary.minecraft.components.PlayerComponent
+import com.mineinabyss.geary.minecraft.dsl.GearyLoadManager
+import com.mineinabyss.geary.minecraft.dsl.GearyLoadPhase
 import com.mineinabyss.geary.minecraft.dsl.attachToGeary
 import com.mineinabyss.geary.minecraft.engine.SpigotEngine
 import com.mineinabyss.idofront.commands.execution.ExperimentalCommandDSL
 import com.mineinabyss.idofront.plugin.registerEvents
 import com.mineinabyss.idofront.plugin.registerService
-import com.okkero.skedule.schedule
 import kotlinx.serialization.InternalSerializationApi
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
@@ -28,7 +29,7 @@ public class GearyPlugin : JavaPlugin() {
         logger.info("On enable has been called")
         saveDefaultConfig()
         reloadConfig()
-        GearyServices.setServiceProvider(object: GearyServiceProvider{
+        GearyServices.setServiceProvider(object : GearyServiceProvider {
             override fun <T : Any> getService(service: KClass<T>): T? {
                 return Bukkit.getServer().servicesManager.load(service.java)
             }
@@ -52,7 +53,6 @@ public class GearyPlugin : JavaPlugin() {
             systems(
                 PassiveActionsSystem,
                 ExpiringComponentSystem,
-
             )
 
             bukkitEntityAccess {
@@ -60,16 +60,17 @@ public class GearyPlugin : JavaPlugin() {
                     add(PlayerComponent(player.uniqueId))
                 }
             }
-        }
 
-        //Register all players with the ECS after all plugins loaded
-        schedule {
-            waitFor(1)
-            Bukkit.getOnlinePlayers().forEach { player ->
-                BukkitEntityAccess.registerEntity(player)
+            startup {
+                GearyLoadPhase.ENABLE {
+                    Bukkit.getOnlinePlayers().forEach { player ->
+                        BukkitEntityAccess.registerEntity(player)
+                    }
+                }
             }
         }
 
+        GearyLoadManager.onEnable()
     }
 
     override fun onDisable() {

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/Helpers.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/Helpers.kt
@@ -1,8 +1,8 @@
 package com.mineinabyss.geary.minecraft
 
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
-import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.entities.addPrefab
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
 import com.mineinabyss.geary.ecs.prefab.PrefabManager
 import com.mineinabyss.geary.minecraft.access.geary
 import com.mineinabyss.geary.minecraft.components.BukkitEntityType

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/access/BukkitEntityAccess.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/access/BukkitEntityAccess.kt
@@ -7,8 +7,8 @@ import com.mineinabyss.geary.ecs.api.engine.Engine
 import com.mineinabyss.geary.ecs.api.engine.entity
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
 import com.mineinabyss.geary.ecs.api.entities.geary
-import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.entities.addPrefab
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
 import com.mineinabyss.geary.ecs.prefab.PrefabManager
 import com.mineinabyss.geary.minecraft.events.GearyEntityRemoveEvent
 import com.mineinabyss.geary.minecraft.events.GearyMinecraftLoadEvent
@@ -60,7 +60,7 @@ public object BukkitEntityAccess : Listener {
         }
 
         //TODO extension function to get prefab key from entity, including correct namespace
-        PrefabManager[PrefabKey("Mobzy", entity.typeName)]?.let {
+        PrefabManager[PrefabKey("mobzy", entity.typeName)]?.let {
             gearyEntity.addPrefab(it)
         }
 

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/access/BukkitEntityAccess.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/access/BukkitEntityAccess.kt
@@ -107,7 +107,7 @@ public object BukkitEntityAccess : Listener {
     public fun EntityRemoveFromWorldEvent.onBukkitEntityRemove() {
         val gearyEntity = getEntityOrNull(entity) ?: return
         //TODO some way of knowing if this entity is permanently removed
-        entity.encodeComponents(gearyEntity.getPersistingComponents())
+        entity.encodeComponents(gearyEntity)
         unregisterEntity(entity)
         gearyEntity.removeEntity()
     }

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/components/PrefabKeyHelpers.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/components/PrefabKeyHelpers.kt
@@ -1,7 +1,11 @@
 package com.mineinabyss.geary.minecraft.components
 
 import com.mineinabyss.geary.ecs.prefab.PrefabKey
+import com.mineinabyss.geary.ecs.prefab.PrefabManager
 import org.bukkit.plugin.Plugin
 
 public fun PrefabKey.Companion.of(plugin: Plugin, name: String): PrefabKey =
     PrefabKey(plugin.name.toLowerCase(), name)
+
+public fun PrefabManager.getPrefabsFor(plugin: Plugin): List<PrefabKey> =
+    getPrefabsFor(plugin.name.toLowerCase())

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/components/PrefabKeyHelpers.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/components/PrefabKeyHelpers.kt
@@ -1,0 +1,7 @@
+package com.mineinabyss.geary.minecraft.components
+
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
+import org.bukkit.plugin.Plugin
+
+public fun PrefabKey.Companion.of(plugin: Plugin, name: String): PrefabKey =
+    PrefabKey(plugin.name.toLowerCase(), name)

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyExtension.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyExtension.kt
@@ -103,13 +103,17 @@ public class GearyExtension(
      */
     @InternalSerializationApi
     public inline fun <reified T : Any> autoscan(
-        init: AutoScanner.() -> Unit = {},
+        crossinline init: AutoScanner.() -> Unit = {},
         noinline addSubclass: SerializerRegistry<T> = { kClass, serializer ->
             if (serializer != null)
                 subclass(kClass, serializer)
         }
     ) {
-        AutoScanner().apply(init).registerSerializers(T::class, addSubclass)
+        startup {
+            GearyLoadPhase.REGISTER_SERIALIZERS {
+                AutoScanner().apply(init).registerSerializers(T::class, addSubclass)
+            }
+        }
     }
 
     private companion object {
@@ -288,24 +292,49 @@ public class GearyExtension(
     }
 
     public fun loadPrefabs(from: File, run: ((String, GearyEntity) -> Unit)? = null) {
-        from.walk().filter { it.isFile }.forEach { file ->
-            val name = file.nameWithoutExtension
-            try {
-                val format = when (val ext = file.extension) {
-                    "yml" -> Formats.yamlFormat
-                    "json" -> Formats.jsonFormat
-                    else -> error("Unknown file format $ext")
+        startup {
+            GearyLoadPhase.LOAD_PREFABS {
+                from.walk().filter { it.isFile }.forEach { file ->
+                    val name = file.nameWithoutExtension
+                    try {
+                        val format = when (val ext = file.extension) {
+                            "yml" -> Formats.yamlFormat
+                            "json" -> Formats.jsonFormat
+                            else -> error("Unknown file format $ext")
+                        }
+                        val type = format.decodeFromString(GearyEntitySerializer, file.readText())
+                        val key = PrefabKey(plugin.name, name)
+                        type.set(key)
+                        PrefabManager.registerPrefab(key, type)
+                        run?.invoke(name, type)
+                    } catch (e: Exception) {
+                        logError("Error deserializing prefab: $name from ${file.path}")
+                        e.printStackTrace()
+                    }
                 }
-                val type = format.decodeFromString(GearyEntitySerializer, file.readText())
-                val key = PrefabKey(plugin.name, name)
-                type.set(key)
-                PrefabManager.registerPrefab(key, type)
-                run?.invoke(name, type)
-            } catch (e: Exception) {
-                logError("Error deserializing prefab: $name from ${file.path}")
-                e.printStackTrace()
             }
         }
+    }
+
+    public class PhaseCreator {
+        public operator fun GearyLoadPhase.invoke(run: () -> Unit) {
+            GearyLoadManager.add(this, run)
+        }
+    }
+
+    /**
+     * Allows defining actions that should run at a specific phase during startup
+     *
+     * Within its context, invoke a [GearyLoadPhase] to run something during it, ex:
+     *
+     * ```
+     * GearyLoadPhase.ENABLE {
+     *     // run code here
+     * }
+     * ```
+     */
+    public inline fun startup(run: PhaseCreator.() -> Unit) {
+        PhaseCreator().apply(run)
     }
 }
 public typealias SerializerRegistry<T> = PolymorphicModuleBuilder<T>.(kClass: KClass<T>, serializer: KSerializer<T>?) -> Unit

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyExtension.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyExtension.kt
@@ -8,11 +8,12 @@ import com.mineinabyss.geary.ecs.api.conditions.GearyCondition
 import com.mineinabyss.geary.ecs.api.engine.Engine
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
 import com.mineinabyss.geary.ecs.api.systems.TickingSystem
-import com.mineinabyss.geary.ecs.components.PrefabKey
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
 import com.mineinabyss.geary.ecs.prefab.PrefabManager
 import com.mineinabyss.geary.ecs.serialization.Formats
 import com.mineinabyss.geary.ecs.serialization.GearyEntitySerializer
 import com.mineinabyss.geary.minecraft.access.BukkitEntityAccess
+import com.mineinabyss.geary.minecraft.components.of
 import com.mineinabyss.idofront.messaging.logError
 import com.mineinabyss.idofront.messaging.logVal
 import com.mineinabyss.idofront.messaging.logWarn
@@ -303,7 +304,7 @@ public class GearyExtension(
                             else -> error("Unknown file format $ext")
                         }
                         val type = format.decodeFromString(GearyEntitySerializer, file.readText())
-                        val key = PrefabKey(plugin.name, name)
+                        val key = PrefabKey.of(plugin, name)
                         type.set(key)
                         PrefabManager.registerPrefab(key, type)
                         run?.invoke(name, type)

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadManager.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadManager.kt
@@ -1,0 +1,21 @@
+package com.mineinabyss.geary.minecraft.dsl
+
+import com.mineinabyss.geary.minecraft.geary
+import com.okkero.skedule.schedule
+
+public object GearyLoadManager {
+    private val actions = sortedMapOf<GearyLoadPhase, MutableList<() -> Unit>>()
+
+    public fun add(phase: GearyLoadPhase, action: () -> Unit) {
+        actions.getOrPut(phase, { mutableListOf() }).add(action)
+    }
+
+    private fun MutableList<() -> Unit>.runAll() = forEach { it() }
+
+    internal fun onEnable() {
+        geary.schedule {
+            waitFor(1)
+            actions.values.forEach { it.runAll() }
+        }
+    }
+}

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadManager.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadManager.kt
@@ -15,7 +15,10 @@ public object GearyLoadManager {
     internal fun onEnable() {
         geary.schedule {
             waitFor(1)
-            actions.values.forEach { it.runAll() }
+            actions[GearyLoadPhase.REGISTER_SERIALIZERS]?.runAll()
+            actions[GearyLoadPhase.LOAD_PREFABS]?.runAll()
+            waitFor(1)
+            actions[GearyLoadPhase.ENABLE]?.runAll()
         }
     }
 }

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadPhase.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadPhase.kt
@@ -1,0 +1,7 @@
+package com.mineinabyss.geary.minecraft.dsl
+
+public enum class GearyLoadPhase {
+    REGISTER_SERIALIZERS,
+    LOAD_PREFABS,
+    ENABLE
+}

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadPhase.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/dsl/GearyLoadPhase.kt
@@ -3,5 +3,5 @@ package com.mineinabyss.geary.minecraft.dsl
 public enum class GearyLoadPhase {
     REGISTER_SERIALIZERS,
     LOAD_PREFABS,
-    ENABLE
+    ENABLE,
 }

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/store/ContainerHelpers.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/store/ContainerHelpers.kt
@@ -1,19 +1,22 @@
 package com.mineinabyss.geary.minecraft.store
 
 import com.mineinabyss.geary.ecs.api.GearyComponent
+import com.mineinabyss.geary.ecs.api.GearyType
+import com.mineinabyss.geary.ecs.api.engine.type
+import com.mineinabyss.geary.ecs.api.entities.GearyEntity
 import com.mineinabyss.idofront.items.editItemMeta
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataHolder
 
 
-public fun PersistentDataHolder.decodeComponents(): Set<GearyComponent> =
+public fun PersistentDataHolder.decodeComponents(): Pair<Set<GearyComponent>, GearyType> =
     persistentDataContainer.decodeComponents()
 
-public fun PersistentDataHolder.encodeComponents(components: Collection<GearyComponent>) {
-    persistentDataContainer.encodeComponents(components)
+public fun PersistentDataHolder.encodeComponents(entity: GearyEntity) {
+    persistentDataContainer.encodeComponents(entity.getPersistingComponents(), entity.type)
 }
 
-public fun ItemStack.decodeComponents(): Set<GearyComponent> =
+public fun ItemStack.decodeComponents(): Pair<Set<GearyComponent>, GearyType> =
     itemMeta.decodeComponents()
 
 public fun ItemStack.encodeComponents(components: Collection<GearyComponent>) {

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/store/DataStore.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/store/DataStore.kt
@@ -3,8 +3,8 @@ package com.mineinabyss.geary.minecraft.store
 import com.mineinabyss.geary.ecs.api.GearyComponent
 import com.mineinabyss.geary.ecs.api.GearyType
 import com.mineinabyss.geary.ecs.api.entities.geary
-import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.engine.INSTANCEOF
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
 import com.mineinabyss.geary.ecs.prefab.PrefabManager
 import com.mineinabyss.geary.ecs.serialization.Formats
 import com.mineinabyss.geary.ecs.serialization.Formats.cborFormat

--- a/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/store/GearyEntityPDC.kt
+++ b/spigot/src/main/kotlin/com/mineinabyss/geary/minecraft/store/GearyEntityPDC.kt
@@ -1,23 +1,23 @@
 package com.mineinabyss.geary.minecraft.store
 
+import com.mineinabyss.geary.ecs.api.engine.type
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
+import com.mineinabyss.geary.ecs.api.entities.geary
+import com.mineinabyss.geary.ecs.entities.addPrefab
 import org.bukkit.persistence.PersistentDataContainer
 
 /** Encodes this entity's persisting components into a [PersistentDataContainer] */
 public fun GearyEntity.encodeComponentsTo(pdc: PersistentDataContainer) {
-    pdc.encodeComponents(getPersistingComponents())
+    pdc.encodeComponents(getPersistingComponents(), type)
 }
 
 /** Decodes a [PersistentDataContainer]'s components, adding them to this entity and its list of persisting components */
 public fun GearyEntity.decodeComponentsFrom(pdc: PersistentDataContainer) {
-    val components = pdc.decodeComponents()
-
-    //TODO implement adding prefabs
-    //if there's a prefab reference on the PDC, we need to add it before we try and decode components from it.
-//    components.asSequence().filterIsInstance<Prefabs>().firstOrNull()?.prefabs?.forEach { addPrefab(it) }
-
-//    type?.decodeComponentsTo(this)
+    val (components, type) = pdc.decodeComponents()
 
     //components written to this entity's PDC will override the ones defined in type
     setAllPersisting(components)
+    for (id in type) {
+        addPrefab(geary(id))
+    }
 }

--- a/src/main/java/com/mineinabyss/geary/ecs/api/entities/GearyEntity.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/api/entities/GearyEntity.kt
@@ -7,6 +7,7 @@ import com.mineinabyss.geary.ecs.api.GearyEntityId
 import com.mineinabyss.geary.ecs.api.engine.Engine
 import com.mineinabyss.geary.ecs.api.engine.componentId
 import com.mineinabyss.geary.ecs.components.PersistingComponents
+import com.mineinabyss.geary.ecs.engine.ENTITY_MASK
 import com.mineinabyss.geary.ecs.engine.HOLDS_DATA
 import kotlin.reflect.KClass
 
@@ -68,8 +69,8 @@ public inline class GearyEntity(public val id: GearyEntityId) {
      *
      * Ex. for bukkit entities this is done through a PersistentDataContainer.
      */
-    public inline fun setPersisting(component: GearyComponent) {
-        set(component)
+    public inline fun <reified T: GearyComponent> setPersisting(component: T, kClass: KClass<out T> = T::class) {
+        set(component, kClass)
         //TODO persisting components should store a list of ComponentIDs
         //TODO is this possible to do nicely with relations?
         getOrSet { PersistingComponents() }.add(component)
@@ -89,7 +90,7 @@ public inline class GearyEntity(public val id: GearyEntityId) {
      * @return Whether the component was present before removal.
      */
     public inline fun <reified T : GearyComponent> remove(): Boolean =
-        remove(componentId<T>())
+        remove(componentId<T>()) || remove(componentId<T>() and ENTITY_MASK)
 
     public inline fun remove(kClass: ComponentClass): Boolean =
         remove(componentId(kClass))
@@ -114,7 +115,7 @@ public inline class GearyEntity(public val id: GearyEntityId) {
 
     /** Gets a persisting component of type [T] or adds a [default] if no component was present. */
     public inline fun <reified T : GearyComponent> getOrSetPersisting(default: () -> T): T =
-        get<T>() ?: default().also { setPersisting(id) }
+        get<T>() ?: default().also { setPersisting<T>(it) }
 
     /** Gets all the active components on this entity. */
     public inline fun getComponents(): Set<GearyComponent> = Engine.getComponentsFor(id)

--- a/src/main/java/com/mineinabyss/geary/ecs/api/entities/GearyEntity.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/api/entities/GearyEntity.kt
@@ -21,6 +21,7 @@ import kotlin.reflect.KClass
  * Thus, there is no longer support for implementing GearyEntity as other classes.
  */
 @Suppress("NOTHING_TO_INLINE")
+//@Serializable
 public inline class GearyEntity(public val id: GearyEntityId) {
     /** Remove this entity from the ECS. */
     public fun removeEntity() {

--- a/src/main/java/com/mineinabyss/geary/ecs/components/CooldownManager.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/components/CooldownManager.kt
@@ -17,7 +17,10 @@ import kotlinx.serialization.Serializable
 @AutoscanComponent
 public class CooldownManager {
     private val completionTime: MutableMap<String, Cooldown> = mutableMapOf()
-    public val incompleteCooldowns: Map<String, Cooldown> get() = completionTime.filterValues { it.endTime > System.currentTimeMillis() }
+    public val incompleteCooldowns: Map<String, Cooldown>
+        get() = completionTime.filterValues {
+            it.endTime > System.currentTimeMillis()
+        }
 
     /** @return Whether a certain cooldown is complete. */
     public fun isDone(key: String): Boolean {

--- a/src/main/java/com/mineinabyss/geary/ecs/components/PersistingPrefabs.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/components/PersistingPrefabs.kt
@@ -1,0 +1,6 @@
+package com.mineinabyss.geary.ecs.components
+
+public data class PersistingPrefabs(
+    val prefabs: Set<PrefabKey>
+) {
+}

--- a/src/main/java/com/mineinabyss/geary/ecs/components/PrefabKey.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/components/PrefabKey.kt
@@ -1,9 +1,0 @@
-package com.mineinabyss.geary.ecs.components
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-public data class PrefabKey(
-    public val plugin: String,
-    public val name: String
-)

--- a/src/main/java/com/mineinabyss/geary/ecs/engine/ArchetypeIterator.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/engine/ArchetypeIterator.kt
@@ -84,6 +84,9 @@ internal class ArchetypeIterator(
      * as we need to do slow indexOf operations.
      */
     internal fun reset() {
+        //TODO we should only be adding stuff here if something is currently iterating over this archetype
+        // we'll remove this line eventually
+        archetype.movedRows.clear()
         row = 0
         relationCombinationsIterator = relationCombinations.iterator()
         componentData = listOf()

--- a/src/main/java/com/mineinabyss/geary/ecs/entities/Relationship.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/entities/Relationship.kt
@@ -54,7 +54,7 @@ public fun GearyEntity.clearChildren() {
 }
 
 public val GearyEntity.parent: GearyEntity?
-    get() = type.firstOrNull { id and CHILDOF != 0uL }?.let { geary(it) }
+    get() = type.firstOrNull { it and CHILDOF != 0uL }?.let { geary(it and ENTITY_MASK) }
 
 public val GearyEntity.parents: Set<GearyEntity>
     get() {

--- a/src/main/java/com/mineinabyss/geary/ecs/entities/Relationship.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/entities/Relationship.kt
@@ -8,6 +8,7 @@ import com.mineinabyss.geary.ecs.api.entities.geary
 import com.mineinabyss.geary.ecs.api.systems.Family
 import com.mineinabyss.geary.ecs.api.systems.SystemManager
 import com.mineinabyss.geary.ecs.components.CopyToInstances
+import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.engine.CHILDOF
 import com.mineinabyss.geary.ecs.engine.ENTITY_MASK
 import com.mineinabyss.geary.ecs.engine.INSTANCEOF
@@ -65,6 +66,9 @@ public val GearyEntity.parents: Set<GearyEntity>
 
 public val GearyEntity.children: List<GearyEntity>
     get() = SystemManager.getEntitiesMatching(Family(sortedSetOf(CHILDOF or id)))
+
+public val GearyEntity.prefabs: List<PrefabKey>
+    get() = type.filter { it and INSTANCEOF != 0uL }.mapNotNull { geary(it).get<PrefabKey>() }
 
 
 /** Adds a [prefab] entity to this entity.  */

--- a/src/main/java/com/mineinabyss/geary/ecs/entities/Relationship.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/entities/Relationship.kt
@@ -8,10 +8,10 @@ import com.mineinabyss.geary.ecs.api.entities.geary
 import com.mineinabyss.geary.ecs.api.systems.Family
 import com.mineinabyss.geary.ecs.api.systems.SystemManager
 import com.mineinabyss.geary.ecs.components.CopyToInstances
-import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.engine.CHILDOF
 import com.mineinabyss.geary.ecs.engine.ENTITY_MASK
 import com.mineinabyss.geary.ecs.engine.INSTANCEOF
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
 
 /** Adds a [parent] entity to this entity.  */
 public fun GearyEntity.addParent(parent: GearyEntity) {

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PersistingPrefabs.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PersistingPrefabs.kt
@@ -1,6 +1,5 @@
-package com.mineinabyss.geary.ecs.components
+package com.mineinabyss.geary.ecs.prefab
 
 public data class PersistingPrefabs(
     val prefabs: Set<PrefabKey>
-) {
-}
+)

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabByReferenceSerializer.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabByReferenceSerializer.kt
@@ -1,7 +1,6 @@
 package com.mineinabyss.geary.ecs.prefab
 
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
-import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.serialization.DescriptorWrapper
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -12,6 +11,7 @@ import kotlinx.serialization.encoding.Encoder
  * Allows us to serialize entity types to a reference to ones actually registered in the system.
  * This is used to load the static entity type when we decode components from an in-game entity.
  */
+@Deprecated("This will not work properly until ktx.serialization fully supports inline classes")
 public object PrefabByReferenceSerializer : KSerializer<GearyEntity> {
     override val descriptor: SerialDescriptor = DescriptorWrapper("geary:prefab", PrefabKey.serializer().descriptor)
 

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabByReferenceSerializer.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabByReferenceSerializer.kt
@@ -2,9 +2,8 @@ package com.mineinabyss.geary.ecs.prefab
 
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
 import com.mineinabyss.geary.ecs.components.PrefabKey
+import com.mineinabyss.geary.ecs.serialization.DescriptorWrapper
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
@@ -14,7 +13,7 @@ import kotlinx.serialization.encoding.Encoder
  * This is used to load the static entity type when we decode components from an in-game entity.
  */
 public object PrefabByReferenceSerializer : KSerializer<GearyEntity> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("geary:prefab", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = DescriptorWrapper("geary:prefab", PrefabKey.serializer().descriptor)
 
     @Suppress("UNCHECKED_CAST")
     override fun deserialize(decoder: Decoder): GearyEntity {

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabKey.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabKey.kt
@@ -1,0 +1,24 @@
+package com.mineinabyss.geary.ecs.prefab
+
+import com.mineinabyss.geary.ecs.api.entities.GearyEntity
+import kotlinx.serialization.Serializable
+
+@Serializable(with = PrefabKeySerializer::class)
+public data class PrefabKey(
+    public val plugin: String,
+    public val name: String
+) {
+    public fun toEntity(): GearyEntity? = PrefabManager[this]
+
+    override fun toString(): String = "$plugin:$name"
+
+    public companion object {
+        public fun of(stringKey: String): PrefabKey {
+            val split = stringKey.split(':')
+            if (split.size != 2)
+                error("Malformatted prefab key: $stringKey. Must only contain one : that splits namespace and key.")
+            val (plugin, name) = split
+            return PrefabKey(plugin, name)
+        }
+    }
+}

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabKeySerializer.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabKeySerializer.kt
@@ -1,0 +1,20 @@
+package com.mineinabyss.geary.ecs.prefab
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+public object PrefabKeySerializer : KSerializer<PrefabKey> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("geary:prefab_key", PrimitiveKind.STRING)
+
+    override fun deserialize(decoder: Decoder): PrefabKey {
+        return PrefabKey.of(decoder.decodeString())
+    }
+
+    override fun serialize(encoder: Encoder, value: PrefabKey) {
+        encoder.encodeString(value.toString())
+    }
+}

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabManager.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabManager.kt
@@ -24,6 +24,9 @@ public object PrefabManager {
         prefab.set(name)
     }
 
+    public fun getPrefabsFor(namespace: String): List<PrefabKey> =
+        keys.filter { it.plugin == namespace }
+
     /** Clears all stored [prefabs] */
     internal fun clear() {
         prefabs.clear()

--- a/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabManager.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/prefab/PrefabManager.kt
@@ -1,7 +1,6 @@
 package com.mineinabyss.geary.ecs.prefab
 
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
-import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.prefab.PrefabManager.keys
 import com.uchuhimo.collections.MutableBiMap
 import com.uchuhimo.collections.mutableBiMapOf

--- a/src/main/java/com/mineinabyss/geary/ecs/serialization/FlatSerializer.kt
+++ b/src/main/java/com/mineinabyss/geary/ecs/serialization/FlatSerializer.kt
@@ -13,7 +13,7 @@ public interface FlatWrap<A> {
 
 /** A wrapper around [SerialDescriptor] that only overrides the [serialName]. */
 @ExperimentalSerializationApi
-private class DescriptorWrapper(override val serialName: String, wrapped: SerialDescriptor) :
+internal class DescriptorWrapper(override val serialName: String, wrapped: SerialDescriptor) :
     SerialDescriptor by wrapped
 
 /**
@@ -21,7 +21,7 @@ private class DescriptorWrapper(override val serialName: String, wrapped: Serial
  * Not technically needed but doing this just in case.
  */
 @ExperimentalSerializationApi
-private class SerializerWrapper<T>(override val descriptor: SerialDescriptor, wrapped: KSerializer<T>) :
+internal class SerializerWrapper<T>(override val descriptor: SerialDescriptor, wrapped: KSerializer<T>) :
     KSerializer<T> by wrapped
 
 /**

--- a/src/main/java/com/mineinabyss/geary/helpers/ComponentHelpers.kt
+++ b/src/main/java/com/mineinabyss/geary/helpers/ComponentHelpers.kt
@@ -1,7 +1,10 @@
 package com.mineinabyss.geary.helpers
 
 import com.mineinabyss.geary.ecs.api.GearyComponent
+import com.mineinabyss.geary.ecs.api.engine.type
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
+import com.mineinabyss.geary.ecs.api.entities.geary
+import com.mineinabyss.geary.ecs.components.PrefabKey
 import com.mineinabyss.geary.ecs.serialization.Formats
 
 /** Gets the serial name of this component as registered in [Formats] */
@@ -13,7 +16,7 @@ private val Collection<GearyComponent>.names: String get() = mapNotNull { it.ser
 /** Neatly lists all the components on this entity. */
 public fun GearyEntity.listComponents(): String {
     return """
-        Static: ${TODO()}
+        Type: ${type.mapNotNull { geary(it).get<PrefabKey>() }}
         Instance: ${getInstanceComponents().names}
         Persisting: ${getPersistingComponents().names}
     """.trimIndent()

--- a/src/main/java/com/mineinabyss/geary/helpers/ComponentHelpers.kt
+++ b/src/main/java/com/mineinabyss/geary/helpers/ComponentHelpers.kt
@@ -4,7 +4,7 @@ import com.mineinabyss.geary.ecs.api.GearyComponent
 import com.mineinabyss.geary.ecs.api.engine.type
 import com.mineinabyss.geary.ecs.api.entities.GearyEntity
 import com.mineinabyss.geary.ecs.api.entities.geary
-import com.mineinabyss.geary.ecs.components.PrefabKey
+import com.mineinabyss.geary.ecs.prefab.PrefabKey
 import com.mineinabyss.geary.ecs.serialization.Formats
 
 /** Gets the serial name of this component as registered in [Formats] */


### PR DESCRIPTION
- Startup system DSL that ensures all plugins execute the code they need to during certain phases
- Create a proper PrefabKey serializer (PrefabByReferenceSerializer still won't work in most cases until proper inline class support arrives)
- Encode prefab references to PDC
- Fix issues with resetting archetype iterator
- Make component removal attempt to remove components regardless of whether they have the `HOLDS_DATA` bit set.