### PR TITLE
Structure cleanup, potential memory leak fix

### DIFF
--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/RegenerateUUIDOnClash.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/RegenerateUUIDOnClash.kt
@@ -1,6 +1,6 @@
 package com.mineinabyss.geary.components
 
 /**
- *
+ * Instructs an entity to regenerate its uuid if it is already taken.
  */
-public object RegenerateUUIDOnClash
+public sealed class RegenerateUUIDOnClash

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/RequestCheck.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/RequestCheck.kt
@@ -3,5 +3,5 @@ package com.mineinabyss.geary.components
 /**
  * A component attached to an event to request handler to check whether it should be successful.
  */
-public object RequestCheck
+public sealed class RequestCheck
 

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/events/EntityRemoved.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/events/EntityRemoved.kt
@@ -1,3 +1,3 @@
 package com.mineinabyss.geary.components.events
 
-public class EntityRemoved
+public sealed class EntityRemoved

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/events/FailedCheck.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/events/FailedCheck.kt
@@ -5,4 +5,4 @@ package com.mineinabyss.geary.components.events
  *
  * @see RequestCheck
  */
-public object FailedCheck
+public sealed class FailedCheck

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
@@ -1,18 +1,17 @@
 package com.mineinabyss.geary.datatypes.maps
 
 import com.mineinabyss.geary.datatypes.GearyComponentId
-import com.mineinabyss.geary.engine.Engine
 import com.mineinabyss.geary.engine.archetypes.Archetype
 import org.koin.core.component.KoinComponent
 
 /**
  * Inlined class that acts as a map of components to archetypes. Uses archetype ids for better performance.
  */
-public class CompId2ArchetypeMap(private val engine: Engine) : KoinComponent {
-    public val inner: MutableMap<Long, Int> = mutableMapOf()
-    public operator fun get(id: GearyComponentId): Archetype = engine.getArchetype(inner[id.toLong()]!!)
+public class CompId2ArchetypeMap : KoinComponent {
+    public val inner: MutableMap<Long, Archetype> = mutableMapOf()
+    public operator fun get(id: GearyComponentId): Archetype? = inner[id.toLong()]
     public operator fun set(id: GearyComponentId, archetype: Archetype) {
-        inner[id.toLong()] = archetype.id
+        inner[id.toLong()] = archetype
     }
 
     public operator fun contains(id: GearyComponentId): Boolean = inner.containsKey(id.toLong())

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/HashTypeMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/HashTypeMap.kt
@@ -1,0 +1,30 @@
+package com.mineinabyss.geary.datatypes.maps
+
+import com.mineinabyss.geary.datatypes.Entity
+import com.mineinabyss.geary.datatypes.Record
+import com.soywiz.kds.*
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+public class HashTypeMap : TypeMap {
+    private val lock = SynchronizedObject()
+    private val map: FastIntMap<Record> = FastIntMap()
+
+    // We don't return nullable record to avoid boxing.
+    // Accessing an entity that doesn't exist is indicative of a problem elsewhere and should be made obvious.
+    override fun get(entity: Entity): Record = synchronized(lock) { map[entity.id.toInt()] }
+        ?: error("Tried to access components on an entity that no longer exists (${entity.id})")
+
+    override fun set(entity: Entity, record: Record): Unit = synchronized(lock) {
+        if (contains(entity)) error("Tried setting the record of an entity that already exists.")
+        map[entity.id.toInt()] = record
+    }
+
+    override fun remove(entity: Entity): Unit = synchronized(lock) {
+        map.remove(entity.id.toInt())
+    }
+
+    override operator fun contains(entity: Entity): Boolean = synchronized(lock) {
+        map.contains(entity.id.toInt())
+    }
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/TypeMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/TypeMap.kt
@@ -2,30 +2,14 @@ package com.mineinabyss.geary.datatypes.maps
 
 import com.mineinabyss.geary.datatypes.Entity
 import com.mineinabyss.geary.datatypes.Record
-import com.soywiz.kds.*
-import kotlinx.atomicfu.locks.SynchronizedObject
-import kotlinx.atomicfu.locks.synchronized
 
-public class TypeMap {
-    private val lock = SynchronizedObject()
-    private val map: FastIntMap<Record> = FastIntMap()
-
+public interface TypeMap {
     // We don't return nullable record to avoid boxing.
     // Accessing an entity that doesn't exist is indicative of a problem elsewhere and should be made obvious.
-    @PublishedApi
-    internal fun get(entity: Entity): Record = synchronized(lock) { map[entity.id.toInt()] }
-        ?: error("Tried to access components on an entity that no longer exists (${entity.id})")
+    public operator fun get(entity: Entity): Record
 
-    @PublishedApi
-    internal fun set(entity: Entity, record: Record): Unit = synchronized(lock) {
-        if (contains(entity)) error("Tried setting the record of an entity that already exists.")
-        map[entity.id.toInt()] = record
-    }
+    public operator fun set(entity: Entity, record: Record)
+    public fun remove(entity: Entity)
 
-    internal fun remove(entity: Entity) = synchronized(lock) {
-        map.remove(entity.id.toInt())
-    }
-
-    public operator fun contains(entity: Entity): Boolean =
-        map.contains(entity.id.toInt())
+    public operator fun contains(entity: Entity): Boolean
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/UUID2GearyMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/UUID2GearyMap.kt
@@ -13,9 +13,7 @@ import com.mineinabyss.geary.systems.GearyListener
 import com.mineinabyss.geary.systems.accessors.EventScope
 import com.mineinabyss.geary.systems.accessors.TargetScope
 
-public class UUID2GearyMap(
-    override val engine: Engine
-) : GearyListener() {
+public class UUID2GearyMap : GearyListener() {
     private val uuid2geary = mutableMapOf<Uuid, Long>()
 
     public operator fun get(uuid: Uuid): GearyEntity? =

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Engine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Engine.kt
@@ -19,10 +19,6 @@ import kotlin.reflect.KClass
  */
 public abstract class Engine : KoinComponent, EngineContext, CoroutineScope {
     override val engine: Engine get() = this
-    public val name: String = "Unnamed Engine"
-
-    /** The root archetype representing a type of no components */
-    public abstract val rootArchetype: Archetype
 
     /** Get the smallest free entity ID. */
     public abstract fun newEntity(initialComponents: Collection<Component> = listOf()): Entity
@@ -92,6 +88,4 @@ public abstract class Engine : KoinComponent, EngineContext, CoroutineScope {
     public abstract fun setRecord(entity: Entity, record: Record)
 
     public abstract fun runSafely(scope: CoroutineScope, job: Job)
-
-    override fun toString(): String = name
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Engine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Engine.kt
@@ -17,43 +17,45 @@ import kotlin.reflect.KClass
  *
  * Its companion object gets a service via Bukkit as its implementation.
  */
-public abstract class Engine : KoinComponent, EngineContext, CoroutineScope {
+public interface Engine : KoinComponent, EngineContext, CoroutineScope {
     override val engine: Engine get() = this
 
     /** Get the smallest free entity ID. */
-    public abstract fun newEntity(initialComponents: Collection<Component> = listOf()): Entity
+    public fun newEntity(initialComponents: Collection<Component> = listOf()): Entity
 
     /** Adds a [system] to the engine, which will be ticked appropriately by the engine */
-    public abstract fun addSystem(system: GearySystem)
+    public fun addSystem(system: GearySystem)
 
     /** Gets a [componentId]'s data from an [entity] or null if not present/the component doesn't hold any data. */
-    public abstract fun getComponentFor(entity: Entity, componentId: ComponentId): Component?
+    public fun getComponentFor(entity: Entity, componentId: ComponentId): Component?
 
     /** Gets a list of all the components [entity] has, as well as relations in the form of [RelationComponent]. */
-    public abstract fun getComponentsFor(entity: Entity): Array<Component>
+    public fun getComponentsFor(entity: Entity): Array<Component>
 
     /**
      * Gets relations in the same format as [Archetype.getRelations], but when kind/target [HOLDS_DATA], the appropriate
      * data is written to a [RelationWithData] object.
      */
-    public abstract fun getRelationsWithDataFor(
+    public fun getRelationsWithDataFor(
         entity: Entity,
         kind: ComponentId,
         target: EntityId
     ): List<RelationWithData<*, *>>
 
+    public fun getRelationsFor(entity: Entity, kind: ComponentId, target: EntityId): List<Relation>
+
     /** Checks whether an [entity] has a [componentId] */
-    public abstract fun hasComponentFor(entity: Entity, componentId: ComponentId): Boolean
+    public fun hasComponentFor(entity: Entity, componentId: ComponentId): Boolean
 
     /** Adds this [componentId] to the [entity]'s type but doesn't store any data. */
-    public abstract fun addComponentFor(entity: Entity, componentId: ComponentId, noEvent: Boolean)
+    public fun addComponentFor(entity: Entity, componentId: ComponentId, noEvent: Boolean)
 
     /**
      * Sets [data] under a [componentId] for an [entity].
      *
      * @param noEvent Whether to fire an [AddedComponent] event.
      */
-    public abstract fun setComponentFor(
+    public fun setComponentFor(
         entity: Entity,
         componentId: ComponentId,
         data: Component,
@@ -61,31 +63,25 @@ public abstract class Engine : KoinComponent, EngineContext, CoroutineScope {
     )
 
     /** Removes a [componentId] from an [entity] and clears any data previously associated with it. */
-    public abstract fun removeComponentFor(entity: Entity, componentId: ComponentId): Boolean
+    public fun removeComponentFor(entity: Entity, componentId: ComponentId): Boolean
 
     /** Removes an entity from the ECS, freeing up its entity id. */
-    public abstract fun removeEntity(entity: Entity, event: Boolean = true)
+    public fun removeEntity(entity: Entity, event: Boolean = true)
 
     /** Removes all components from an entity. */
-    public abstract fun clearEntity(entity: Entity)
+    public fun clearEntity(entity: Entity)
+
+    /** Gets an [entity]'s type */
+    public fun getType(entity: Entity): EntityType
 
     /**
      * Given a component's [kClass], returns its [ComponentId], or registers an entity
      * with a [ComponentInfo] that will represent this [kClass]'s component type.
      */
-    public abstract fun getOrRegisterComponentIdForClass(kClass: KClass<*>): ComponentId
+    public fun getOrRegisterComponentIdForClass(kClass: KClass<*>): ComponentId
 
-    /** Gets an archetype by id or throws an error if it doesn't exist in this engine. */
-    public abstract fun getArchetype(id: Int): Archetype
+    public fun runSafely(scope: CoroutineScope, job: Job)
 
-    /** Gets or creates an archetype from a [type]. */
-    public abstract fun getArchetype(type: EntityType): Archetype
-
-    /** Gets the record of a given entity, or throws an error if the entity id is not active in the engine. */
-    internal abstract fun getRecord(entity: Entity): Record
-
-    /** Updates the record of a given entity */
-    public abstract fun setRecord(entity: Entity, record: Record)
-
-    public abstract fun runSafely(scope: CoroutineScope, job: Job)
+    /** Calls an event on [target] with data in an [event] entity, optionally with a [source] entity. */
+    public fun callEvent(target: Entity, event: Entity, source: Entity?)
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/EntityProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/EntityProvider.kt
@@ -1,0 +1,9 @@
+package com.mineinabyss.geary.engine
+
+import com.mineinabyss.geary.datatypes.*
+
+public interface EntityProvider {
+    public fun newEntity(initialComponents: Collection<Component>): Entity
+
+    public fun removeEntity(entity: Entity)
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/EventRunner.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/EventRunner.kt
@@ -1,0 +1,7 @@
+package com.mineinabyss.geary.engine
+
+import com.mineinabyss.geary.datatypes.Record
+
+public interface EventRunner {
+    public fun callEvent(target: Record, event: Record, source: Record?)
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/TickingEngine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/TickingEngine.kt
@@ -2,7 +2,7 @@ package com.mineinabyss.geary.engine
 
 import kotlin.time.Duration
 
-public abstract class TickingEngine : Engine() {
+public abstract class TickingEngine : Engine {
     public abstract val tickDuration: Duration
 
     private var started: Boolean = false

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeEngine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeEngine.kt
@@ -205,14 +205,14 @@ public open class ArchetypeEngine(override val tickDuration: Duration) : Ticking
         }
 
         val (archetype, row) = getRecord(entity)
-        archetype.scheduleRemoveRow(row)
+        archetype.removeEntity(row)
         //add current id into queue for reuse
         entityProvider.removeEntity(entity)
     }
 
     override fun clearEntity(entity: Entity) {
         val (archetype, row) = getRecord(entity)
-        archetype.scheduleRemoveRow(row)
+        archetype.removeEntity(row)
         archetypeProvider.rootArchetype.addEntityWithData(getRecord(entity), arrayOf(), entity)
     }
 
@@ -251,7 +251,6 @@ public open class ArchetypeEngine(override val tickDuration: Duration) : Ticking
     override suspend fun tick(currentTick: Long): Unit = coroutineScope {
         // Create a job but don't start it
         val job = launch(start = CoroutineStart.LAZY) {
-            cleanup()
             registeredSystems
                 .filter { currentTick % (it.interval / tickDuration).toInt().coerceAtLeast(1) == 0L }
                 .forEach {
@@ -279,12 +278,5 @@ public open class ArchetypeEngine(override val tickDuration: Duration) : Ticking
 
     override fun callEvent(target: Entity, event: Entity, source: Entity?) {
         eventRunner.callEvent(getRecord(target), getRecord(event), source?.let { getRecord(it) })
-    }
-
-    private fun cleanup() {
-        queuedCleanup.forEach { archetype ->
-            archetype.cleanup()
-        }
-        queuedCleanup.clear()
     }
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeEventRunner.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeEventRunner.kt
@@ -1,0 +1,59 @@
+package com.mineinabyss.geary.engine.archetypes
+
+import com.mineinabyss.geary.datatypes.Record
+import com.mineinabyss.geary.engine.EventRunner
+import com.mineinabyss.geary.helpers.contains
+import com.mineinabyss.geary.systems.accessors.RawAccessorDataScope
+
+public class ArchetypeEventRunner: EventRunner {
+    override fun callEvent(target: Record, event: Record, source: Record?) {
+        val origEventArc = event.archetype
+        val origTargetArc = target.archetype
+        val origSourceArc = source?.archetype
+
+        //TODO performance upgrade will come when we figure out a solution in QueryManager as well.
+        for (handler in origEventArc.eventHandlers) {
+            // If an event handler has moved the entity to a new archetype, make sure we follow it.
+            val (targetArc, targetRow) = target
+            val (eventArc, eventRow) = event
+            val sourceArc = source?.archetype
+            val sourceRow = source?.row
+
+            // If there's no source but the handler needs a source, skip
+            if (source == null && !handler.parentListener.source.isEmpty) continue
+
+            // Check that this handler has a listener associated with it.
+            if (!handler.parentListener.target.isEmpty && handler.parentListener !in targetArc.targetListeners) continue
+            if (sourceArc != null && !handler.parentListener.source.isEmpty && handler.parentListener !in sourceArc.sourceListeners) continue
+
+            // Check that we still match the data if archetype of any involved entities changed.
+            if (targetArc != origTargetArc && targetArc.type !in handler.parentListener.target.family) continue
+            if (eventArc != origEventArc && eventArc.type !in handler.parentListener.event.family) continue
+            if (sourceArc != origSourceArc && eventArc.type !in handler.parentListener.source.family) continue
+
+            val listenerName = handler.parentListener::class.simpleName
+            val targetScope = runCatching {
+                RawAccessorDataScope(
+                    archetype = targetArc,
+                    perArchetypeData = handler.parentListener.target.cacheForArchetype(targetArc),
+                    row = targetRow,
+                )
+            }.getOrElse { throw IllegalStateException("Failed while reading target scope on $listenerName", it) }
+            val eventScope = runCatching {
+                RawAccessorDataScope(
+                    archetype = eventArc,
+                    perArchetypeData = handler.parentListener.event.cacheForArchetype(eventArc),
+                    row = eventRow,
+                )
+            }.getOrElse { throw IllegalStateException("Failed while reading event scope on $listenerName", it) }
+            val sourceScope = if (source == null) null else runCatching {
+                RawAccessorDataScope(
+                    archetype = sourceArc!!,
+                    perArchetypeData = handler.parentListener.source.cacheForArchetype(sourceArc),
+                    row = sourceRow!!,
+                )
+            }.getOrElse { throw IllegalStateException("Failed while reading source scope on $listenerName", it) }
+            handler.processAndHandle(sourceScope, targetScope, eventScope)
+        }
+    }
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeProvider.kt
@@ -1,0 +1,8 @@
+package com.mineinabyss.geary.engine.archetypes
+
+import com.mineinabyss.geary.datatypes.EntityType
+
+public interface ArchetypeProvider {
+    public val rootArchetype: Archetype
+    public fun newArchetype(entityType: EntityType): Archetype
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeProvider.kt
@@ -4,5 +4,7 @@ import com.mineinabyss.geary.datatypes.EntityType
 
 public interface ArchetypeProvider {
     public val rootArchetype: Archetype
-    public fun newArchetype(entityType: EntityType): Archetype
+    public val count: Int
+//    public fun newArchetype(entityType: EntityType): Archetype
+    public fun getArchetype(entityType: EntityType): Archetype
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/EntityByArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/EntityByArchetypeProvider.kt
@@ -1,0 +1,46 @@
+package com.mineinabyss.geary.engine.archetypes
+
+import com.mineinabyss.geary.datatypes.*
+import com.mineinabyss.geary.datatypes.maps.TypeMap
+import com.mineinabyss.geary.engine.EntityProvider
+import com.mineinabyss.geary.helpers.componentId
+import com.mineinabyss.geary.helpers.toGeary
+import kotlinx.atomicfu.atomic
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+public class EntityByArchetypeProvider(
+    private val removedEntities: EntityStack = EntityStack()
+) : EntityProvider, KoinComponent {
+    private val typeMap: TypeMap by inject()
+    private val archetypeProvider: ArchetypeProvider by inject()
+
+    private val currId = atomic(0L)
+    override fun newEntity(initialComponents: Collection<Component>): GearyEntity {
+        val entity = try {
+            removedEntities.pop()
+        } catch (e: Exception) {
+            currId.getAndIncrement().toGeary()
+        }
+        createRecord(entity, initialComponents)
+        return entity
+    }
+
+
+    private fun createRecord(entity: Entity, initialComponents: Collection<Component>) {
+        val ids = initialComponents.map { componentId(it::class) } + initialComponents.map { componentId(it::class) or HOLDS_DATA }
+        val addTo = archetypeProvider.getArchetype(EntityType(ids))
+        val record = Record(archetypeProvider.rootArchetype, -1)
+        addTo.addEntityWithData(
+            record,
+            initialComponents.toTypedArray().apply { sortBy { addTo.indexOf(componentId(it::class)) } },
+            entity,
+        )
+        typeMap[entity] = record
+    }
+
+    override fun removeEntity(entity: Entity) {
+        typeMap.remove(entity)
+        removedEntities.push(entity)
+    }
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/SimpleArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/SimpleArchetypeProvider.kt
@@ -1,13 +1,41 @@
 package com.mineinabyss.geary.engine.archetypes
 
+import com.mineinabyss.geary.datatypes.ComponentId
 import com.mineinabyss.geary.datatypes.EntityType
+import com.mineinabyss.geary.datatypes.maps.TypeMap
+import com.mineinabyss.geary.engine.EventRunner
+import com.mineinabyss.geary.systems.QueryManager
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-public class SimpleArchetypeProvider: ArchetypeProvider {
-    override val rootArchetype: Archetype
-        get() = Archetype(this, EntityType(), 0)
+public class SimpleArchetypeProvider : ArchetypeProvider, KoinComponent {
+    private val queryManager: QueryManager by inject()
+    private val typeMap: TypeMap by inject()
+    private val eventRunner: EventRunner by inject()
 
+    override val rootArchetype: Archetype = Archetype(this, typeMap, eventRunner, EntityType(), 0)
+    private val archetypes = mutableListOf(rootArchetype)
+    override val count: Int get() = archetypes.size
 
-    override fun newArchetype(entityType: EntityType): Archetype {
-        TODO("Not yet implemented")
+    public val archetypeCount: Int get() = archetypes.size
+    private val archetypeWriteLock = SynchronizedObject()
+
+    private fun createArchetype(prevNode: Archetype, componentEdge: ComponentId): Archetype {
+        val arc = Archetype(this, typeMap, eventRunner,prevNode.type.plus(componentEdge), archetypes.size)
+            .also { archetypes += it }
+        arc.componentRemoveEdges[componentEdge] = prevNode
+        prevNode.componentAddEdges[componentEdge] = arc
+        queryManager.registerArchetype(arc)
+        return arc
+    }
+
+    override fun getArchetype(entityType: EntityType): Archetype = synchronized(archetypeWriteLock) {
+        var node = rootArchetype
+        entityType.forEach { compId ->
+            node = node.componentAddEdges[compId] ?: createArchetype(node, compId)
+        }
+        return node
     }
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/SimpleArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/SimpleArchetypeProvider.kt
@@ -1,0 +1,13 @@
+package com.mineinabyss.geary.engine.archetypes
+
+import com.mineinabyss.geary.datatypes.EntityType
+
+public class SimpleArchetypeProvider: ArchetypeProvider {
+    override val rootArchetype: Archetype
+        get() = Archetype(this, EntityType(), 0)
+
+
+    override fun newArchetype(entityType: EntityType): Archetype {
+        TODO("Not yet implemented")
+    }
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/events/CheckHandler.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/events/CheckHandler.kt
@@ -23,7 +23,7 @@ public abstract class CheckHandler(
     override fun handle(source: SourceScope?, target: TargetScope, event: EventScope) {
         if (!check(source, target, event)) event.entity.apply {
             remove<RequestCheck>()
-            set(FailedCheck)
+            add<FailedCheck>()
         }
     }
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/helpers/ArchetypeHelpers.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/helpers/ArchetypeHelpers.kt
@@ -3,15 +3,10 @@ package com.mineinabyss.geary.helpers
 import com.mineinabyss.geary.context.globalContext
 import com.mineinabyss.geary.datatypes.EntityType
 import com.mineinabyss.geary.engine.archetypes.Archetype
+import com.mineinabyss.geary.engine.archetypes.ArchetypeEngine
 import com.soywiz.kds.IntSet
 import com.soywiz.kds.intSetOf
 
+// TODO context to avoid cast
 public fun EntityType.getArchetype(): Archetype =
-    globalContext.engine.getArchetype(this)
-
-public fun Archetype.countChildren(vis: IntSet = intSetOf()): Int {
-    componentAddEdges.inner.values.filter { it !in vis }
-        .forEach { globalContext.engine.getArchetype(it).countChildren(vis) }
-    vis.addAll(componentAddEdges.inner.values)
-    return vis.count()
-}
+    (globalContext.engine as ArchetypeEngine).archetypeProvider.getArchetype(this)

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/serialization/Formats.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/serialization/Formats.kt
@@ -2,6 +2,8 @@ package com.mineinabyss.geary.serialization
 
 import com.mineinabyss.geary.datatypes.Component
 import kotlinx.serialization.cbor.Cbor
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
 /**
  * A singleton for accessing different serialization formats with all the registered serializers for [Component]s
@@ -9,9 +11,8 @@ import kotlinx.serialization.cbor.Cbor
  *
  * Will likely be converted into a service eventually.
  */
-public class Formats(
-    serializers: Serializers
-) {
+public class Formats: KoinComponent {
+    private val serializers: Serializers by inject()
     private val formatMap = mutableMapOf<String, PrefabFormat>()
 
     /** The format to use for encoding binary data (usually not to files) */

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/systems/QueryManager.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/systems/QueryManager.kt
@@ -57,7 +57,6 @@ public class QueryManager {
     //TODO convert to Sequence
     public fun getEntitiesMatching(family: Family): List<Entity> {
         return archetypes.match(family).flatMap { arc ->
-            arc.cleanup()
             arc.entities
         }
     }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/systems/QueryManager.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/systems/QueryManager.kt
@@ -6,11 +6,12 @@ import com.mineinabyss.geary.datatypes.Entity
 import com.mineinabyss.geary.datatypes.family.Family
 import com.mineinabyss.geary.datatypes.maps.Family2ObjectArrayMap
 import com.mineinabyss.geary.engine.archetypes.Archetype
+import com.mineinabyss.geary.engine.archetypes.ArchetypeEngine
 import com.mineinabyss.geary.events.Handler
 import com.mineinabyss.geary.helpers.contains
 import com.mineinabyss.geary.systems.query.GearyQuery
 
-public class QueryManager : EngineContext by GearyContextKoin() {
+public class QueryManager {
     private val queries = mutableListOf<GearyQuery>()
     private val sourceListeners = mutableListOf<Listener>()
     private val targetListeners = mutableListOf<Listener>()
@@ -18,8 +19,8 @@ public class QueryManager : EngineContext by GearyContextKoin() {
 
     private val archetypes = Family2ObjectArrayMap<Archetype>()
 
-    public fun init() {
-        registerArchetype(engine.rootArchetype)
+    public fun init(engine: ArchetypeEngine) {
+        registerArchetype(engine.archetypeProvider.rootArchetype)
     }
 
     public fun trackEventListener(listener: Listener) {

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/systems/query/Query.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/systems/query/Query.kt
@@ -46,12 +46,10 @@ public abstract class Query : AccessorHolder(), Iterable<TargetScope>, GearyCont
         val matched = matchedArchetypes.toList()
         val sizes = matched.map { it.size - 1 }
         matched.fastForEachWithIndex { i, archetype ->
-            archetype.cleanup()
             archetype.isIterating = true
             archetype.iteratorFor(this@Query).forEach(upTo = sizes[i]) { targetScope ->
                 run(targetScope)
             }
-            archetype.cleanup()
             archetype.isIterating = false
         }
     }

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/AsyncArchetypeTests.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/AsyncArchetypeTests.kt
@@ -9,7 +9,6 @@ import com.mineinabyss.geary.helpers.toGeary
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.time.measureTime
@@ -18,9 +17,10 @@ class AsyncArchetypeTests : GearyTest() {
     @Test
     fun `add entities concurrently`() = runTest {
         clearEngine()
-        val arc = engine.getArchetype(EntityType(ulongArrayOf(componentId<String>() or HOLDS_DATA)))
+        val arc = engine.archetypeProvider.getArchetype(EntityType(ulongArrayOf(componentId<String>() or HOLDS_DATA)))
         concurrentOperation(10000) {
-            arc.addEntityWithData(engine.newEntity().getRecord(), arrayOf("Test"))
+            val rec = engine.getRecord(engine.newEntity())
+            arc.addEntityWithData(rec, arrayOf("Test"), rec.entity)
         }.awaitAll()
         arc.entities.size shouldBe 10000
         arc.entities.shouldBeUnique()
@@ -28,19 +28,15 @@ class AsyncArchetypeTests : GearyTest() {
 
 
     // The two tests below are pretty beefy and more like benchmarks so they're disabled by default
-//    @Test
+    @Test
     fun `set and remove concurrency`() = runTest {
         println(measureTime {
             concurrentOperation(100) {
                 val entity = entity()
-                repeat(1000) { id ->
-                    launch {
-//                        entity.withLock {
-                        entity.setRelation("String", id.toULong().toGeary())
-                        println("Locked for ${entity.id}: $id, size ${engine.archetypeCount}")
-//                        }
-                    }
-                }
+                concurrentOperation(1000) { id ->
+                    entity.setRelation("String", id.toULong().toGeary())
+                }.awaitAll()
+                println("Finished for ${entity.id}, arc size ${engine.archetypeProvider.count}")
             }.awaitAll()
         })
 //        entity.getComponents().shouldBeEmpty()
@@ -65,11 +61,11 @@ class AsyncArchetypeTests : GearyTest() {
         println(measureTime {
             for (i in 0 until iters) {
 //            concurrentOperation(iters) { i ->
-                engine.getArchetype(EntityType((0uL..i.toULong()).toList()))
-                println("Creating arc $i, total: ${engine.archetypeCount}")
+                engine.archetypeProvider.getArchetype(EntityType((0uL..i.toULong()).toList()))
+                println("Creating arc $i, total: ${engine.archetypeProvider.count}")
 //            }.awaitAll()
             }
         })
-        engine.archetypeCount shouldBe iters + 1
+        engine.archetypeProvider.count shouldBe iters + 1
     }
 }

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/AsyncArchetypeTests.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/AsyncArchetypeTests.kt
@@ -9,8 +9,11 @@ import com.mineinabyss.geary.helpers.toGeary
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 
 class AsyncArchetypeTests : GearyTest() {
@@ -28,16 +31,17 @@ class AsyncArchetypeTests : GearyTest() {
 
 
     // The two tests below are pretty beefy and more like benchmarks so they're disabled by default
-    @Test
+    //TODO move into benchmark and turn back into concurrent version when we actually support concurrency
+//    @Test
     fun `set and remove concurrency`() = runTest {
         println(measureTime {
-            concurrentOperation(100) {
+            repeat(1000000) {
                 val entity = entity()
-                concurrentOperation(1000) { id ->
+                repeat(0) { id ->
                     entity.setRelation("String", id.toULong().toGeary())
-                }.awaitAll()
-                println("Finished for ${entity.id}, arc size ${engine.archetypeProvider.count}")
-            }.awaitAll()
+                }//.awaitAll()
+//                    println("Finished for ${entity.id}, arc size ${engine.archetypeProvider.count}")
+            }//.awaitAll()
         })
 //        entity.getComponents().shouldBeEmpty()
     }

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/ConcurrentSystemModificationTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/ConcurrentSystemModificationTest.kt
@@ -11,7 +11,8 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class ConcurrentSystemModificationTest : GearyTest() {
-    @Test
+    //TODO put back when we support concurrency lol
+//    @Test
     fun `concurrent modification`() = runTest {
         clearEngine()
         var ran = 0

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/GearyEntityTests.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/GearyEntityTests.kt
@@ -36,7 +36,7 @@ internal class GearyEntityTests : GearyTest() {
         entity {
             add<String>()
             set(1)
-        }.type.getArchetype() shouldBe engine.rootArchetype + componentId<String>() + componentId<Int>() + (HOLDS_DATA or componentId<Int>())
+        }.type.getArchetype() shouldBe engine.archetypeProvider.rootArchetype + componentId<String>() + componentId<Int>() + (HOLDS_DATA or componentId<Int>())
     }
 
     @Test
@@ -44,7 +44,7 @@ internal class GearyEntityTests : GearyTest() {
         entity {
             set("Test")
             remove<String>()
-        }.type.getArchetype() shouldBe engine.rootArchetype
+        }.type.getArchetype() shouldBe engine.archetypeProvider.rootArchetype
     }
 
     @Test
@@ -52,7 +52,7 @@ internal class GearyEntityTests : GearyTest() {
         entity {
             add<String>()
             set("Test")
-        }.type.getArchetype() shouldBe engine.rootArchetype + componentId<String>() + (componentId<String>() or HOLDS_DATA)
+        }.type.getArchetype() shouldBe engine.archetypeProvider.rootArchetype + componentId<String>() + (componentId<String>() or HOLDS_DATA)
     }
 
     @Test

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/engine/ArchetypeTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/engine/ArchetypeTest.kt
@@ -17,29 +17,31 @@ import org.junit.jupiter.api.Test
 internal class ArchetypeTest : GearyTest() {
     @Nested
     inner class ArchetypeNavigation {
+        val root = engine.archetypeProvider.rootArchetype
+
         @Test
         fun `archetype ids assigned correctly`() {
-            engine.rootArchetype.id shouldBe 0
+            root.id shouldBe 0
             // Some other archetypes are created on start, but following ones should come in order
-            val start = (engine.rootArchetype + 1u).id
-            (engine.rootArchetype + 1u + 2u).id shouldBe start + 1
-            (engine.rootArchetype + 1u).id shouldBe start
+            val start = (root + 1u).id
+            (root + 1u + 2u).id shouldBe start + 1
+            (root + 1u).id shouldBe start
         }
 
         @Test
         fun `empty type represents empty archetype`() {
-            EntityType().getArchetype() shouldBe engine.rootArchetype
+            EntityType().getArchetype() shouldBe root
         }
 
         @Test
         fun `getArchetype returns same as manual archetype adding`() {
-            engine.rootArchetype + 1u + 2u + 3u - 1u + 1u shouldBe
+            root + 1u + 2u + 3u - 1u + 1u shouldBe
                     EntityType(listOf(1u, 2u, 3u)).getArchetype()
         }
 
         @Test
         fun `reach same archetype from different starting positions`() {
-            engine.rootArchetype + 1u + 2u + 3u shouldBe engine.rootArchetype + 3u + 2u + 1u
+            root + 1u + 2u + 3u shouldBe root + 3u + 2u + 1u
         }
     }
 
@@ -51,7 +53,9 @@ internal class ArchetypeTest : GearyTest() {
         val instanceOf = Relation.of<InstanceOf?>(target)
         val instanceOf2 = Relation.of<InstanceOf?>(target2)
         val arc = Archetype(
-            engine,
+            engine.archetypeProvider,
+            engine.typeMap,
+            engine.eventRunner,
             EntityType(listOf(persists.id, instanceOf.id, instanceOf2.id)),
             0
         )

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
@@ -4,9 +4,9 @@ import com.mineinabyss.geary.context.EngineContext
 import com.mineinabyss.geary.context.GearyContextKoin
 import com.mineinabyss.geary.context.QueryContext
 import com.mineinabyss.geary.context.globalContext
-import com.mineinabyss.geary.engine.ArchetypeEngine
 import com.mineinabyss.geary.engine.Components
 import com.mineinabyss.geary.engine.Engine
+import com.mineinabyss.geary.engine.archetypes.ArchetypeEngine
 import com.mineinabyss.geary.systems.QueryManager
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
@@ -4,9 +4,13 @@ import com.mineinabyss.geary.context.EngineContext
 import com.mineinabyss.geary.context.GearyContextKoin
 import com.mineinabyss.geary.context.QueryContext
 import com.mineinabyss.geary.context.globalContext
+import com.mineinabyss.geary.datatypes.maps.HashTypeMap
+import com.mineinabyss.geary.datatypes.maps.TypeMap
 import com.mineinabyss.geary.engine.Components
 import com.mineinabyss.geary.engine.Engine
-import com.mineinabyss.geary.engine.archetypes.ArchetypeEngine
+import com.mineinabyss.geary.engine.EntityProvider
+import com.mineinabyss.geary.engine.EventRunner
+import com.mineinabyss.geary.engine.archetypes.*
 import com.mineinabyss.geary.systems.QueryManager
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -14,7 +18,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.AfterAll
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.logger.Logger
@@ -23,8 +26,8 @@ import org.koin.dsl.module
 import kotlin.time.Duration.Companion.milliseconds
 
 abstract class GearyTest : KoinComponent, EngineContext {
-    override val engine get() = get<Engine>() as ArchetypeEngine
-    val queryManager get() = get<QueryManager>()
+    override val engine get() = globalContext.engine as ArchetypeEngine
+    val queryManager get() = globalContext.queryManager
 
     init {
         clearEngine()
@@ -34,19 +37,22 @@ abstract class GearyTest : KoinComponent, EngineContext {
         with(object : QueryContext {
             override val queryManager = QueryManager()
         }) {
-            val engine = ArchetypeEngine(10.milliseconds)
             @Suppress("RemoveExplicitTypeArguments")
             startKoin {
                 modules(module {
                     single<Logger> { PrintLogger() }
                     single { Components() }
-                    factory<QueryManager> { queryManager }
-                    factory<Engine> { engine }
+                    single<QueryManager> { queryManager }
+                    single<TypeMap> { HashTypeMap() }
+                    single<EventRunner> { ArchetypeEventRunner() }
+                    single<EntityProvider> { EntityByArchetypeProvider() }
+                    single<ArchetypeProvider> { SimpleArchetypeProvider() }
+                    single<Engine> { ArchetypeEngine(10.milliseconds) }
                 })
             }
             globalContext = GearyContextKoin()
             engine.init()
-            queryManager.init()
+            queryManager.init(engine)
         }
     }
 

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/FamilyMatchingTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/FamilyMatchingTest.kt
@@ -27,7 +27,8 @@ class FamilyMatchingTest: GearyTest() {
         }
     }
 
-    val correctArchetype = engine.rootArchetype + stringId + intId
+    val root = engine.archetypeProvider.rootArchetype
+    val correctArchetype = root + stringId + intId
 
     init {
         queryManager.trackQuery(system)
@@ -35,7 +36,7 @@ class FamilyMatchingTest: GearyTest() {
 
     @Test
     fun `family type is correct`() {
-        EntityType(system.family.components).getArchetype() shouldBe engine.rootArchetype + stringId
+        EntityType(system.family.components).getArchetype() shouldBe root + stringId
     }
 
     @Test

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/QueryManagerTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/QueryManagerTest.kt
@@ -25,8 +25,8 @@ internal class QueryManagerTest : GearyTest() {
     @Test
     fun `empty event handler`() {
         engine.addSystem(EventListener)
-        (engine.rootArchetype.type in EventListener.event.family) shouldBe true
-        engine.rootArchetype.eventHandlers.map { it.parentListener } shouldContain EventListener
+        (engine.archetypeProvider.rootArchetype.type in EventListener.event.family) shouldBe true
+        engine.archetypeProvider.rootArchetype.eventHandlers.map { it.parentListener } shouldContain EventListener
         entity {
             set(TestComponent())
         }.callEvent()

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ group=com.mineinabyss
 version=0.19
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
-idofrontVersion=0.12.106
+idofrontVersion=0.12.107
 kotlinVersion=1.6.10
 serverVersion=1.19.2-R0.1-SNAPSHOT
 dokkaVersion=1.6.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.mineinabyss
-version=0.19
+version=0.20
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 idofrontVersion=0.12.107

--- a/platforms/papermc/core/src/main/kotlin/com/mineinabyss/geary/papermc/engine/PaperMCEngine.kt
+++ b/platforms/papermc/core/src/main/kotlin/com/mineinabyss/geary/papermc/engine/PaperMCEngine.kt
@@ -2,7 +2,7 @@ package com.mineinabyss.geary.papermc.engine
 
 import co.aikar.timings.Timings
 import com.github.shynixn.mccoroutine.bukkit.minecraftDispatcher
-import com.mineinabyss.geary.engine.ArchetypeEngine
+import com.mineinabyss.geary.engine.archetypes.ArchetypeEngine
 import com.mineinabyss.geary.systems.GearySystem
 import com.mineinabyss.geary.systems.RepeatingSystem
 import com.mineinabyss.idofront.plugin.registerEvents

--- a/platforms/papermc/plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyCommands.kt
+++ b/platforms/papermc/plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyCommands.kt
@@ -1,13 +1,11 @@
 package com.mineinabyss.geary.papermc.plugin
 
-import com.mineinabyss.geary.helpers.countChildren
 import com.mineinabyss.geary.papermc.GearyMCContext
 import com.mineinabyss.geary.papermc.GearyMCContextKoin
 import com.mineinabyss.geary.papermc.StartupEventListener
 import com.mineinabyss.geary.prefabs.PrefabKey
 import com.mineinabyss.idofront.commands.arguments.stringArg
 import com.mineinabyss.idofront.commands.execution.IdofrontCommandExecutor
-import com.mineinabyss.idofront.messaging.info
 import com.rylinaux.plugman.util.PluginUtil
 import kotlinx.coroutines.launch
 import org.bukkit.command.CommandSender
@@ -34,12 +32,11 @@ internal class GearyCommands : IdofrontCommandExecutor(), TabCompleter, GearyMCC
                     depends.forEach { PluginUtil.load(it.name) }
                 }
             }
-            "countArchetypes" {
-                action {
-                    sender.info("${engine.rootArchetype.countChildren()} archetypes registered.")
-                }
-
-            }
+//            "countArchetypes" {
+//                action {
+//                    sender.info("${(engine).rootArchetype.countChildren()} archetypes registered.")
+//                }
+//            }
             //TODO reimplement
             /*"components"{
                 val type by stringArg()
@@ -64,15 +61,18 @@ internal class GearyCommands : IdofrontCommandExecutor(), TabCompleter, GearyMCC
                 "fullreload",
                 "countArchetypes"
             )
+
             2 -> {
                 when (args[0]) {
                     "reread" -> prefabManager.keys.filter {
                         val arg = args[1].lowercase()
                         it.key.startsWith(arg) || it.full.startsWith(arg)
                     }.map { it.toString() }
+
                     else -> listOf()
                 }
             }
+
             else -> listOf()
         }
     }

--- a/platforms/papermc/plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
+++ b/platforms/papermc/plugin/src/main/kotlin/com/mineinabyss/geary/papermc/plugin/GearyPluginImpl.kt
@@ -2,9 +2,14 @@ package com.mineinabyss.geary.papermc.plugin
 
 import com.mineinabyss.geary.addon.*
 import com.mineinabyss.geary.addon.GearyLoadPhase.ENABLE
+import com.mineinabyss.geary.datatypes.maps.HashTypeMap
+import com.mineinabyss.geary.datatypes.maps.TypeMap
 import com.mineinabyss.geary.datatypes.maps.UUID2GearyMap
 import com.mineinabyss.geary.engine.Components
 import com.mineinabyss.geary.engine.Engine
+import com.mineinabyss.geary.engine.EntityProvider
+import com.mineinabyss.geary.engine.EventRunner
+import com.mineinabyss.geary.engine.archetypes.*
 import com.mineinabyss.geary.formats.YamlFormat
 import com.mineinabyss.geary.helpers.withSerialName
 import com.mineinabyss.geary.papermc.GearyConfig
@@ -15,6 +20,7 @@ import com.mineinabyss.geary.papermc.access.toGeary
 import com.mineinabyss.geary.papermc.dsl.GearyMCAddonManager
 import com.mineinabyss.geary.papermc.dsl.gearyAddon
 import com.mineinabyss.geary.papermc.engine.PaperMCEngine
+import com.mineinabyss.geary.papermc.globalContextMC
 import com.mineinabyss.geary.papermc.store.FileSystemStore
 import com.mineinabyss.geary.papermc.store.GearyStore
 import com.mineinabyss.geary.prefabs.PrefabManager
@@ -45,34 +51,30 @@ class GearyPluginImpl : GearyPlugin() {
         saveDefaultConfig()
         reloadConfig()
 
-        val engine = PaperMCEngine(this@GearyPluginImpl)
-        val serializers = Serializers()
-        val formats = Formats(serializers)
-        val queryManager = QueryManager()
-        val uuid2GearyMap = UUID2GearyMap(engine)
-        val prefabManager = PrefabManager()
-        val addonManager = GearyMCAddonManager()
-        val bukkitEntity2Geary = BukkitEntity2Geary()
-
         startOrAppendKoin(module {
             single<Logger> { GearyLogger(this@GearyPluginImpl) }
             single<GearyPlugin> { this@GearyPluginImpl }
-            single<QueryManager> { queryManager }
-            single<Engine> { engine }
-            single<BukkitEntity2Geary> { bukkitEntity2Geary }
-            single<UUID2GearyMap> { uuid2GearyMap }
-            single<GearyAddonManager> { addonManager }
-            single<PrefabManager> { prefabManager }
-            single<Serializers> { serializers }
-            single<Formats> { formats }
+            single<QueryManager> { QueryManager() }
+            single<TypeMap> { HashTypeMap() }
+            single<EventRunner> { ArchetypeEventRunner() }
+            single<EntityProvider> { EntityByArchetypeProvider() }
+            single<ArchetypeProvider> { SimpleArchetypeProvider() }
+            single<Engine> { PaperMCEngine(this@GearyPluginImpl) }
+            single<BukkitEntity2Geary> { BukkitEntity2Geary() }
+            single<UUID2GearyMap> { UUID2GearyMap() }
+            single<GearyAddonManager> { GearyMCAddonManager() }
+            single<PrefabManager> { PrefabManager() }
+            single<Serializers> { Serializers() }
+            single<Formats> { Formats() }
             single<Components> { Components() }
             singleConfig<GearyConfig>(this@GearyPluginImpl)
         })
 
+        val engine = globalContextMC.engine
         engine.start()
-        queryManager.init()
-        uuid2GearyMap.startTracking()
-        bukkitEntity2Geary.startTracking()
+        globalContextMC.queryManager.init(engine)
+        globalContextMC.uuid2entity.startTracking()
+        globalContextMC.bukkit2Geary.startTracking()
 
         gearyAddon {
             autoscan("com.mineinabyss") {


### PR DESCRIPTION
- Use composition to split some engine functions into injectable objects
- Don't schedule entity remove in hopes to fix a memory leak. Regresses some steps in async support but I'm planning a different approach for it in the future