### PR TITLE
🐛 Bugfixes - things should actually start up now

### DIFF
--- a/addons/geary-autoscan/build.gradle.kts
+++ b/addons/geary-autoscan/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    id(libs.plugins.mia.kotlin.asProvider().get().pluginId)
+    id(libs.plugins.mia.kotlin.jvm.get().pluginId)
     id(libs.plugins.mia.publication.get().pluginId)
     alias(libs.plugins.kotlinx.serialization)
 }
@@ -9,7 +9,9 @@ dependencies {
     compileOnly(project(":geary-core"))
     compileOnly(project(":geary-serialization"))
 
-    implementation(libs.reflections)
+    //TODO remove from platform and move into mylibs
+//    implementation(libs.reflections)
+    implementation("org.reflections:reflections:0.10.2")
     implementation(libs.kotlin.reflect)
     implementation(libs.idofront.di)
     implementation(libs.idofront.autoscan)

--- a/addons/geary-autoscan/build.gradle.kts
+++ b/addons/geary-autoscan/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
     //TODO remove from platform and move into mylibs
 //    implementation(libs.reflections)
-    implementation("org.reflections:reflections:0.10.2")
+    implementation(libs.reflections)
     implementation(libs.kotlin.reflect)
     implementation(libs.idofront.di)
     implementation(libs.idofront.autoscan)

--- a/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScanner.kt
+++ b/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScanner.kt
@@ -18,7 +18,7 @@ interface AutoScanner {
 
     companion object Addon : GearyAddonWithDefault<AutoScanner> {
         override fun default() = object : AutoScanner {
-            private val logger = geary.logger
+            private val logger get() = geary.logger
             override val scannedComponents = mutableSetOf<KClass<*>>()
             override val scannedSystems = mutableSetOf<KClass<*>>()
 

--- a/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScannerDSL.kt
+++ b/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScannerDSL.kt
@@ -9,8 +9,9 @@ import com.mineinabyss.geary.systems.System
 import kotlinx.serialization.*
 import kotlinx.serialization.modules.polymorphic
 import org.reflections.Reflections
-import org.reflections.util.ClasspathHelper
+import org.reflections.scanners.Scanners
 import org.reflections.util.ConfigurationBuilder
+import org.reflections.util.FilterBuilder
 import kotlin.reflect.KClass
 import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.isSubclassOf
@@ -28,17 +29,13 @@ class AutoScannerDSL(
     private val classLoader: ClassLoader,
     private val limitTo: List<String>
 ) {
-    private val logger = geary.logger
+    private val logger get() = geary.logger
 
     private val reflections: Reflections by lazy {
         Reflections(
             ConfigurationBuilder()
-                .addClassLoader(classLoader)
-                .apply {
-                    limitTo.forEach { pkg ->
-                        addUrls(ClasspathHelper.forPackage(pkg, classLoader))
-                    }
-                }
+                .apply { limitTo.forEach { forPackage(it, classLoader) } }
+                .filterInputsBy(FilterBuilder().apply { limitTo.forEach { includePackage(it) } })
         )
     }
 
@@ -60,7 +57,7 @@ class AutoScannerDSL(
      */
     fun components() {
         val scanned = reflections
-            .getTypesAnnotatedWith(Serializable::class.java)
+            .get(Scanners.TypesAnnotated.with(Serializable::class.java).asClass<Class<*>>())
             .asSequence()
             .map { it.kotlin }
             .filter { !it.hasAnnotation<ExcludeAutoScan>() }
@@ -96,25 +93,28 @@ class AutoScannerDSL(
 
 
     /** Registers a polymorphic serializer for this [kClass], scanning for any subclasses. */
-    fun <T: Any> subClassesOf(kClass: KClass<T>) {
-        val scanned = reflections.getSubTypesOf(kClass.java)
-            .asSequence()
-            .map { it.kotlin }
-            .filter { !it.hasAnnotation<ExcludeAutoScan>() }
+    @OptIn(InternalSerializationApi::class)
+    fun <T : Any> subClassesOf(kClass: KClass<T>) {
 
         geary {
             serialization {
                 module {
                     polymorphic(kClass) {
-                        scanned.forEach { component(it) }
+                        val scanned = this@AutoScannerDSL.reflections.getSubTypesOf(kClass.java)
+                            .asSequence()
+                            .map { it.kotlin }
+                            .filter { !it.hasAnnotation<ExcludeAutoScan>() }
+                            .filterIsInstance<KClass<T>>()
+
+                        scanned.forEach { subclass(it, it.serializer()) }
+                        this@AutoScannerDSL.logger.i("Autoscan found subclasses for ${kClass.simpleName}: ${scanned.joinToString { it.simpleName!! }}")
                     }
                 }
             }
         }
 
-        logger.i("Autoscan found subclasses for ${kClass.simpleName}: ${scanned.joinToString { it.simpleName!! }}")
     }
 
     /** @see subClassesOf */
-    inline fun  <reified T : Any> subClassesOf() = subClassesOf(T::class)
+    inline fun <reified T : Any> subClassesOf() = subClassesOf(T::class)
 }

--- a/addons/geary-common-features/build.gradle.kts
+++ b/addons/geary-common-features/build.gradle.kts
@@ -1,6 +1,6 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    id(libs.plugins.mia.kotlin.asProvider().get().pluginId)
+    id(libs.plugins.mia.kotlin.jvm.get().pluginId)
     id(libs.plugins.mia.publication.get().pluginId)
 }
 

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
@@ -28,13 +28,13 @@ class PrefabLoader {
 
     internal fun loadPrefabs() {
         val loaded = readFiles.flatMap { read ->
-            read.get().mapNotNull { path ->
+            read.get().map { path ->
                 loadFromPath(read.namespace, path).onFailure {
-                    logger.e("Can't read prefab ${path.name} from ${path}:\n${it.cause?.stackTraceToString()}")
-                }.getOrNull()
+                    logger.e("Could not read prefab $path:\n\u001B[37m${it.message}")
+                }
             }
         }
-        logger.i("Loaded ${loaded.size} prefabs")
+        logger.i("Loaded ${loaded.count { it.isSuccess }}/${loaded.count()} prefabs")
     }
 
     /** If this entity has a [Prefab] component, clears it and loads components from its file. */

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
@@ -18,7 +18,7 @@ class PrefabLoader {
     private val manager get() = prefabs.manager
     private val formats get() = serializableComponents.formats
 
-    private val logger = geary.logger
+    private val logger get() = geary.logger
 
     private val readFiles = mutableListOf<PrefabPath>()
 

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabsDSL.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabsDSL.kt
@@ -22,6 +22,7 @@ class PrefabsDSL(
         loader.addSource(PrefabPath(namespaced.namespace) {
             fileSystem
                 .listRecursively(folder, true)
+                .filter { it.name.contains('.') }
         })
     }
 }

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabsDSL.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabsDSL.kt
@@ -22,7 +22,6 @@ class PrefabsDSL(
         loader.addSource(PrefabPath(namespaced.namespace) {
             fileSystem
                 .listRecursively(folder, true)
-                .filter { it.name.endsWith(".yml") }
         })
     }
 }

--- a/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/dsl/SerializableComponents.kt
+++ b/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/dsl/SerializableComponents.kt
@@ -28,7 +28,7 @@ interface SerializableComponents {
 
         override fun Builder.install() {
             geary.pipeline.intercept(GearyPhase.ADDONS_CONFIGURED) {
-                DI.add(object : SerializableComponents {
+                DI.add<SerializableComponents>(object : SerializableComponents {
                     override val serializers = serializersBuilder.build()
                     override val formats = formatsBuilder.build(serializers)
                 })

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyArchetypeModule.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyArchetypeModule.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 val archetypes: GearyArchetypeModule by DI.observe()
 
-data class GearyArchetypeModule(
+open class GearyArchetypeModule(
     val tickDuration: Duration = 50.milliseconds,
 ) : GearyModule {
     override val logger = Logger.withTag("Geary")
@@ -34,8 +34,6 @@ data class GearyArchetypeModule(
     override val components by lazy { Components() }
 
     override fun inject() {
-        DI.add<GearyModule>(this)
-        DI.add(this)
         componentProvider.createComponentInfo()
     }
 

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
@@ -1,12 +1,14 @@
 package com.mineinabyss.geary.helpers.tests
 
 import com.mineinabyss.geary.modules.GearyArchetypeModule
+import com.mineinabyss.geary.modules.GearyModule
 import com.mineinabyss.idofront.di.DI
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
 import kotlin.time.Duration.Companion.milliseconds
 
 abstract class GearyTest {
@@ -19,6 +21,8 @@ abstract class GearyTest {
 
     fun startEngine() {
         val module = GearyArchetypeModule(tickDuration = 20.milliseconds)
+        DI.add<GearyArchetypeModule>(module)
+        DI.add<GearyModule>(module)
         module.inject()
         geary = module
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group=com.mineinabyss
 version=0.22
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
-idofrontVersion=0.16.11
+idofrontVersion=0.17.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group=com.mineinabyss
 version=0.22
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
-idofrontVersion=0.16.8
+idofrontVersion=0.16.11

--- a/gradle/mylibs.versions.toml
+++ b/gradle/mylibs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-atomicfu = "0.18.5"
+atomicfu = "0.20.0"
 
 [libraries]
 atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.0.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven("https://repo.mineinabyss.com/releases")
-        maven("https://repo.papermc.io/repository/maven-public/")
+//        maven("https://repo.papermc.io/repository/maven-public/")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,9 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             from("com.mineinabyss:catalog:$idofrontVersion")
+            // Version overrides
             version("kotlin", "1.8.10")
+            version("reflections", "0.10.2")
         }
         create("mylibs").from(files("gradle/mylibs.versions.toml"))
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,10 @@ dependencyResolutionManagement {
     }
 
     versionCatalogs {
-        create("libs").from("com.mineinabyss:catalog:$idofrontVersion")
+        create("libs") {
+            from("com.mineinabyss:catalog:$idofrontVersion")
+            version("kotlin", "1.8.10")
+        }
         create("mylibs").from(files("gradle/mylibs.versions.toml"))
     }
 }


### PR DESCRIPTION
### Misc
- Update Kotlin version to be able to run tests on newer Gradle (later Idofront will need this updated)
- Update Idofront and Gradle
- Fix addons not being reused if already registered by automatically injecting into DI
- Fix accessing DI logger without `get()`

### Autoscan
- Update reflections library and correctly exclude classes outside of given package scopes
- Add back autoscanning subclasses of a class in the form of `subClassesOf`

### Prefabs
- Improve prefab loading messages
- Fix prefab keys containing file extension