### PR TITLE
Update idofront version

### DIFF
--- a/addons/geary-autoscan/build.gradle.kts
+++ b/addons/geary-autoscan/build.gradle.kts
@@ -9,10 +9,7 @@ dependencies {
     compileOnly(project(":geary-core"))
     compileOnly(project(":geary-serialization"))
 
-    //TODO remove from platform and move into mylibs
-//    implementation(libs.reflections)
     implementation(libs.reflections)
     implementation(libs.kotlin.reflect)
     implementation(libs.idofront.di)
-    implementation(libs.idofront.autoscan)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ group=com.mineinabyss
 version=0.22
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
-idofrontVersion=0.17.0
+idofrontVersion=0.18.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,10 +18,6 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             from("com.mineinabyss:catalog:$idofrontVersion")
-            // Version overrides
-            version("kotlin", "1.8.10")
-            version("dokka", "1.8.10")
-            version("reflections", "0.10.2")
         }
         create("mylibs").from(files("gradle/mylibs.versions.toml"))
     }


### PR DESCRIPTION
This bumps Kotlin so we don't have to specify overrides