### PR TITLE
Engine setup providers

### DIFF
--- a/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScanner.kt
+++ b/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScanner.kt
@@ -34,7 +34,6 @@ interface AutoScanner {
         }
 
         override fun AutoScanner.install() {
-            DI.add(this)
             geary.pipeline.intercept(GearyPhase.INIT_SYSTEMS) {
                 installSystems()
             }

--- a/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScannerDSL.kt
+++ b/addons/geary-autoscan/src/main/kotlin/com/mineinabyss/geary/autoscan/AutoScannerDSL.kt
@@ -57,7 +57,7 @@ class AutoScannerDSL(
      */
     fun components() {
         val scanned = reflections
-            .get(Scanners.TypesAnnotated.with(Serializable::class.java).asClass<Class<*>>())
+            .get(Scanners.TypesAnnotated.with(Serializable::class.java).asClass<Class<*>>(classLoader))
             .asSequence()
             .map { it.kotlin }
             .filter { !it.hasAnnotation<ExcludeAutoScan>() }
@@ -83,7 +83,8 @@ class AutoScannerDSL(
      * @see AutoScanner
      */
     fun systems() {
-        val scanned = reflections.getTypesAnnotatedWith(AutoScan::class.java)
+        val scanned = reflections
+            .get(Scanners.TypesAnnotated.with(AutoScan::class.java).asClass<Class<*>>(classLoader))
             .asSequence()
             .map { it.kotlin }
             .filter { !it.hasAnnotation<ExcludeAutoScan>() && it.isSubclassOf(System::class) }
@@ -95,12 +96,12 @@ class AutoScannerDSL(
     /** Registers a polymorphic serializer for this [kClass], scanning for any subclasses. */
     @OptIn(InternalSerializationApi::class)
     fun <T : Any> subClassesOf(kClass: KClass<T>) {
-
         geary {
             serialization {
                 module {
                     polymorphic(kClass) {
-                        val scanned = this@AutoScannerDSL.reflections.getSubTypesOf(kClass.java)
+                        val scanned = this@AutoScannerDSL.reflections
+                            .get(Scanners.SubTypes.of(kClass.java).asClass<Class<*>>(this@AutoScannerDSL.classLoader))
                             .asSequence()
                             .map { it.kotlin }
                             .filter { !it.hasAnnotation<ExcludeAutoScan>() }

--- a/addons/geary-common-features/build.gradle.kts
+++ b/addons/geary-common-features/build.gradle.kts
@@ -2,6 +2,7 @@
 plugins {
     id(libs.plugins.mia.kotlin.jvm.get().pluginId)
     id(libs.plugins.mia.publication.get().pluginId)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 dependencies {

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
@@ -61,7 +61,7 @@ class PrefabLoader {
             entity.setAll(decoded)
 
             val key = PrefabKey.of(namespace, path.name.substringBeforeLast('.'))
-            manager.registerPrefab(key, entity)
+            entity.set(key)
             entity
         }
     }

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabManager.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabManager.kt
@@ -17,7 +17,6 @@ class PrefabManager {
     /** Registers a prefab with Geary. */
     fun registerPrefab(key: PrefabKey, prefab: Entity) {
         keyToPrefab[key] = prefab
-        prefab.set(key)
     }
 
     /** Gets all prefabs registered under a certain [namespace]. */

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/Prefabs.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/Prefabs.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.geary.prefabs.configuration.systems.ParseChildOnPrefab
 import com.mineinabyss.geary.prefabs.configuration.systems.ParseChildrenOnPrefab
 import com.mineinabyss.geary.prefabs.configuration.systems.ParseRelationOnPrefab
 import com.mineinabyss.geary.prefabs.configuration.systems.ParseRelationWithDataSystem
+import com.mineinabyss.geary.prefabs.systems.TrackPrefabsByKeySystem
 import com.mineinabyss.idofront.di.DI
 
 val prefabs by DI.observe<Prefabs>()
@@ -31,6 +32,7 @@ interface Prefabs {
                 ParseChildrenOnPrefab(),
                 ParseRelationOnPrefab(),
                 ParseRelationWithDataSystem(),
+                TrackPrefabsByKeySystem(),
             )
             geary.pipeline.intercept(GearyPhase.INIT_ENTITIES) {
                 loader.loadPrefabs()

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/Prefabs.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/Prefabs.kt
@@ -26,7 +26,6 @@ interface Prefabs {
 
 
         override fun Prefabs.install() {
-            DI.add(this)
             geary.pipeline.addSystems(
                 ParseChildOnPrefab(),
                 ParseChildrenOnPrefab(),

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/systems/TrackPrefabsByKeySystem.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/systems/TrackPrefabsByKeySystem.kt
@@ -1,0 +1,16 @@
+package com.mineinabyss.geary.prefabs.systems
+
+import com.mineinabyss.geary.annotations.Handler
+import com.mineinabyss.geary.prefabs.PrefabKey
+import com.mineinabyss.geary.prefabs.prefabs
+import com.mineinabyss.geary.systems.Listener
+import com.mineinabyss.geary.systems.accessors.TargetScope
+
+class TrackPrefabsByKeySystem : Listener() {
+    private val TargetScope.key by onSet<PrefabKey>().onTarget()
+
+    @Handler
+    private fun TargetScope.registerOnSet() {
+        prefabs.manager.registerPrefab(key, entity)
+    }
+}

--- a/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/dsl/FileSystemAddon.kt
+++ b/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/dsl/FileSystemAddon.kt
@@ -9,7 +9,6 @@ val fileSystem by DI.observe<FileSystem>()
 interface FileSystemAddon {
     companion object : GearyAddon<FileSystem> {
         override fun FileSystem.install() {
-            DI.add(this)
         }
     }
 }

--- a/addons/geary-uuid/src/commonMain/kotlin/com/mineinabyss/geary/uuid/UUIDTracking.kt
+++ b/addons/geary-uuid/src/commonMain/kotlin/com/mineinabyss/geary/uuid/UUIDTracking.kt
@@ -12,7 +12,6 @@ object UUIDTracking : GearyAddonWithDefault<UUID2GearyMap> {
     override fun default() = UUID2GearyMap()
 
     override fun UUID2GearyMap.install() {
-        DI.add(this)
         geary.pipeline.addSystems(
             TrackUuidOnAdd(),
             UnTrackUuidOnRemove()

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Engine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Engine.kt
@@ -8,4 +8,7 @@ import kotlinx.coroutines.CoroutineScope
  * Its companion object gets a service via Bukkit as its implementation.
  */
 interface Engine : CoroutineScope {
+
+    /** Ticks the entire engine. Implementations may call at different speeds. */
+    suspend fun tick(currentTick: Long)
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/TickingEngine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/TickingEngine.kt
@@ -7,9 +7,6 @@ abstract class TickingEngine : Engine {
 
     private var started: Boolean = false
 
-    /** Ticks the entire engine. Implementations may call at different speeds. */
-    abstract suspend fun tick(currentTick: Long)
-
     open fun start(): Boolean {
         if (!started) {
             scheduleSystemTicking()

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeEngine.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeEngine.kt
@@ -44,11 +44,11 @@ open class ArchetypeEngine(override val tickDuration: Duration) : TickingEngine(
             pipeline.getRepeatingInExecutionOrder()
                 .filter { currentTick % (it.interval / tickDuration).toInt().coerceAtLeast(1) == 0L }
                 .also { logger.v("Ticking engine with systems $it") }
-                .forEach {
+                .forEach { system ->
                     runCatching {
-                        it.runSystem()
+                        system.runSystem()
                     }.onFailure {
-                        logger.e("Error while running system ${it::class.simpleName}")
+                        logger.e("Error while running system ${system::class.simpleName}")
                         it.printStackTrace()
                     }
                 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/helpers/ArchetypeHelpers.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/helpers/ArchetypeHelpers.kt
@@ -1,10 +1,10 @@
 package com.mineinabyss.geary.helpers
 
-import com.mineinabyss.geary.modules.GearyArchetypeModule
+import com.mineinabyss.geary.modules.ArchetypeEngineModule
 import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.datatypes.EntityType
 import com.mineinabyss.geary.engine.archetypes.Archetype
 
 // TODO context to avoid cast
 fun EntityType.getArchetype(): Archetype =
-    (geary as GearyArchetypeModule).archetypeProvider.getArchetype(this)
+    (geary as ArchetypeEngineModule).archetypeProvider.getArchetype(this)

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/ArchetypeEngineModule.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/ArchetypeEngineModule.kt
@@ -34,7 +34,7 @@ open class ArchetypeEngineModule(
 
     override val components by lazy { Components() }
 
-    companion object: GearyModuleProviderWithDefault<ArchetypeEngineModule> {
+    companion object : GearyModuleProviderWithDefault<ArchetypeEngineModule> {
         override fun default(): ArchetypeEngineModule {
             return ArchetypeEngineModule()
         }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyConfiguration.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyConfiguration.kt
@@ -42,7 +42,6 @@ class GearyConfiguration {
      * }
      * ```
      */
-
     fun on(phase: GearyPhase, run: () -> Unit) {
         geary.pipeline.intercept(phase, run)
     }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyModule.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyModule.kt
@@ -7,6 +7,24 @@ import com.mineinabyss.idofront.di.DI
 
 val geary: GearyModule by DI.observe()
 
+fun <T : GearyModule> geary(
+    moduleProvider: GearyModuleProviderWithDefault<T>,
+    configuration: GearyConfiguration.() -> Unit = {}
+) {
+    val module = moduleProvider.default()
+    geary(moduleProvider, module, configuration)
+}
+
+fun <T : GearyModule> geary(
+    moduleProvider: GearyModuleProvider<T>,
+    module: T,
+    configuration: GearyConfiguration.() -> Unit = {}
+) {
+    moduleProvider.init(module)
+    module.invoke(configuration)
+    moduleProvider.start(module)
+}
+
 @GearyDSL
 interface GearyModule {
     val logger: Logger
@@ -23,11 +41,10 @@ interface GearyModule {
     val eventRunner: EventRunner
     val pipeline: Pipeline
 
-    fun inject()
-    fun start()
-
     operator fun invoke(configure: GearyConfiguration.() -> Unit) {
         GearyConfiguration().apply(configure)
     }
+
+    companion object
 }
 

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyModuleProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyModuleProvider.kt
@@ -1,0 +1,6 @@
+package com.mineinabyss.geary.modules
+
+interface GearyModuleProvider<T : GearyModule> {
+    fun init(module: T)
+    fun start(module: T)
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyModuleProviderWithDefault.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/GearyModuleProviderWithDefault.kt
@@ -1,0 +1,5 @@
+package com.mineinabyss.geary.modules
+
+interface GearyModuleProviderWithDefault<T : GearyModule> : GearyModuleProvider<T> {
+    fun default(): T
+}

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/TestEngineModule.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/TestEngineModule.kt
@@ -1,19 +1,27 @@
 package com.mineinabyss.geary.modules
 
+import com.mineinabyss.geary.engine.archetypes.EntityByArchetypeProvider
+
 /**
  * An engine module that does initializes the engine but does not start it.
  *
  * No pipeline tasks are run, and the engine won't be scheduled for ticking.
  * Engine ticks may still be called manually.
  */
-object TestEngineModule: GearyModuleProviderWithDefault<ArchetypeEngineModule> {
-    override fun init(module: ArchetypeEngineModule) {
-        ArchetypeEngineModule.init(module)
-    }
+class TestEngineModule(
+    reuseIDsAfterRemoval: Boolean = true,
+): ArchetypeEngineModule() {
+    override val entityProvider = EntityByArchetypeProvider(reuseIDsAfterRemoval)
 
-    override fun start(module: ArchetypeEngineModule) = Unit
+    companion object: GearyModuleProviderWithDefault<TestEngineModule> {
+        override fun init(module: TestEngineModule) {
+            ArchetypeEngineModule.init(module)
+        }
 
-    override fun default(): ArchetypeEngineModule {
-        return ArchetypeEngineModule()
+        override fun start(module: TestEngineModule) = Unit
+
+        override fun default(): TestEngineModule {
+            return TestEngineModule()
+        }
     }
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/TestEngineModule.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/modules/TestEngineModule.kt
@@ -1,0 +1,19 @@
+package com.mineinabyss.geary.modules
+
+/**
+ * An engine module that does initializes the engine but does not start it.
+ *
+ * No pipeline tasks are run, and the engine won't be scheduled for ticking.
+ * Engine ticks may still be called manually.
+ */
+object TestEngineModule: GearyModuleProviderWithDefault<ArchetypeEngineModule> {
+    override fun init(module: ArchetypeEngineModule) {
+        ArchetypeEngineModule.init(module)
+    }
+
+    override fun start(module: ArchetypeEngineModule) = Unit
+
+    override fun default(): ArchetypeEngineModule {
+        return ArchetypeEngineModule()
+    }
+}

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/AsyncArchetypeTests.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/AsyncArchetypeTests.kt
@@ -6,6 +6,8 @@ import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.tests.GearyTest
 import com.mineinabyss.geary.helpers.toGeary
+import com.mineinabyss.geary.modules.archetypes
+import com.mineinabyss.geary.modules.geary
 import io.kotest.matchers.collections.shouldBeUnique
 import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.awaitAll
@@ -14,14 +16,16 @@ import org.junit.jupiter.api.Test
 import kotlin.time.measureTime
 
 class AsyncArchetypeTests : GearyTest() {
+    private val concurrentEntityAmount = 10000
+
     @Test
     fun `add entities concurrently`() = runTest {
-        val arc = geary.archetypeProvider.getArchetype(EntityType(ulongArrayOf(componentId<String>() or HOLDS_DATA)))
-        concurrentOperation(10000) {
-            val rec = geary.records[geary.entityProvider.create()]
+        val arc = archetypes.archetypeProvider.getArchetype(EntityType(ulongArrayOf(componentId<String>() or HOLDS_DATA)))
+        concurrentOperation(concurrentEntityAmount) {
+            val rec = archetypes.records[geary.entityProvider.create()]
             arc.addEntityWithData(rec, arrayOf("Test"), rec.entity)
         }.awaitAll()
-        arc.entities.size shouldBe 10000
+        arc.entities.size shouldBe concurrentEntityAmount
         arc.entities.shouldBeUnique()
     }
 
@@ -61,11 +65,11 @@ class AsyncArchetypeTests : GearyTest() {
         println(measureTime {
             for (i in 0 until iters) {
 //            concurrentOperation(iters) { i ->
-                geary.archetypeProvider.getArchetype(EntityType((0uL..i.toULong()).toList()))
-                println("Creating arc $i, total: ${geary.archetypeProvider.count}")
+                archetypes.archetypeProvider.getArchetype(EntityType((0uL..i.toULong()).toList()))
+                println("Creating arc $i, total: ${archetypes.archetypeProvider.count}")
 //            }.awaitAll()
             }
         })
-        geary.archetypeProvider.count shouldBe iters + 1
+        archetypes.archetypeProvider.count shouldBe iters + 1
     }
 }

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/ConcurrentSystemModificationTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/async/ConcurrentSystemModificationTest.kt
@@ -3,6 +3,7 @@ package com.mineinabyss.geary.async
 import com.mineinabyss.geary.datatypes.family.family
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.systems.RepeatingSystem
 import com.mineinabyss.geary.systems.accessors.TargetScope
 import io.kotest.matchers.collections.shouldContainExactly

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/GearyEntityTests.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/GearyEntityTests.kt
@@ -6,6 +6,7 @@ import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.getArchetype
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.archetypes
 import com.mineinabyss.geary.systems.accessors.RelationWithData
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -36,7 +37,7 @@ internal class GearyEntityTests : GearyTest() {
         entity {
             add<String>()
             set(1)
-        }.type.getArchetype() shouldBe geary.archetypeProvider.rootArchetype + componentId<String>() + componentId<Int>() + (HOLDS_DATA or componentId<Int>())
+        }.type.getArchetype() shouldBe archetypes.archetypeProvider.rootArchetype + componentId<String>() + componentId<Int>() + (HOLDS_DATA or componentId<Int>())
     }
 
     @Test
@@ -44,7 +45,7 @@ internal class GearyEntityTests : GearyTest() {
         entity {
             set("Test")
             remove<String>()
-        }.type.getArchetype() shouldBe geary.archetypeProvider.rootArchetype
+        }.type.getArchetype() shouldBe archetypes.archetypeProvider.rootArchetype
     }
 
     @Test
@@ -52,7 +53,7 @@ internal class GearyEntityTests : GearyTest() {
         entity {
             add<String>()
             set("Test")
-        }.type.getArchetype() shouldBe geary.archetypeProvider.rootArchetype + componentId<String>() + (componentId<String>() or HOLDS_DATA)
+        }.type.getArchetype() shouldBe archetypes.archetypeProvider.rootArchetype + componentId<String>() + (componentId<String>() or HOLDS_DATA)
     }
 
     @Test

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/engine/ArchetypeTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/engine/ArchetypeTest.kt
@@ -9,6 +9,7 @@ import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.getArchetype
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.archetypes
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Nested
@@ -17,7 +18,7 @@ import org.junit.jupiter.api.Test
 internal class ArchetypeTest : GearyTest() {
     @Nested
     inner class ArchetypeNavigation {
-        val root = geary.archetypeProvider.rootArchetype
+        val root = archetypes.archetypeProvider.rootArchetype
 
         @Test
         fun `archetype ids assigned correctly`() {

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/engine/GearyEngineTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/engine/GearyEngineTest.kt
@@ -3,6 +3,7 @@ package com.mineinabyss.geary.engine
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.tests.GearyTest
 import com.mineinabyss.geary.helpers.toGeary
+import com.mineinabyss.geary.modules.geary
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/events/ComponentAddEventTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/events/ComponentAddEventTest.kt
@@ -4,6 +4,7 @@ import com.mineinabyss.geary.annotations.Handler
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.getArchetype
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.systems.Listener
 import com.mineinabyss.geary.systems.accessors.TargetScope
 import io.kotest.matchers.shouldBe

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/events/SourceTargetEventTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/events/SourceTargetEventTest.kt
@@ -4,6 +4,7 @@ import com.mineinabyss.geary.annotations.Handler
 import com.mineinabyss.geary.datatypes.family.family
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.systems.Listener
 import com.mineinabyss.geary.systems.accessors.EventScope
 import com.mineinabyss.geary.systems.accessors.SourceScope

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/GearyTestTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/GearyTestTest.kt
@@ -1,6 +1,7 @@
 package com.mineinabyss.geary.helpers
 
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.geary
 import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/helpers/tests/GearyTest.kt
@@ -1,30 +1,21 @@
 package com.mineinabyss.geary.helpers.tests
 
-import com.mineinabyss.geary.modules.GearyArchetypeModule
-import com.mineinabyss.geary.modules.GearyModule
+import com.mineinabyss.geary.modules.TestEngineModule
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.idofront.di.DI
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import kotlin.time.Duration.Companion.milliseconds
 
 abstract class GearyTest {
-    lateinit var geary: GearyArchetypeModule
-        private set
-
     init {
         startEngine()
     }
 
     fun startEngine() {
-        val module = GearyArchetypeModule(tickDuration = 20.milliseconds)
-        DI.add<GearyArchetypeModule>(module)
-        DI.add<GearyModule>(module)
-        module.inject()
-        geary = module
+        geary(TestEngineModule)
     }
 
     @AfterAll

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/FamilyMatchingTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/FamilyMatchingTest.kt
@@ -7,6 +7,8 @@ import com.mineinabyss.geary.helpers.componentId
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.getArchetype
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.archetypes
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.systems.accessors.TargetScope
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
@@ -27,7 +29,7 @@ class FamilyMatchingTest : GearyTest() {
         }
     }
 
-    val root = geary.archetypeProvider.rootArchetype
+    val root = archetypes.archetypeProvider.rootArchetype
     val correctArchetype = root + stringId + intId
 
     init {

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/QueryManagerTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/QueryManagerTest.kt
@@ -4,6 +4,8 @@ import com.mineinabyss.geary.annotations.Handler
 import com.mineinabyss.geary.helpers.contains
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.archetypes
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.systems.accessors.TargetScope
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
@@ -25,8 +27,8 @@ internal class QueryManagerTest : GearyTest() {
     @Test
     fun `empty event handler`() {
         geary.pipeline.addSystem(EventListener)
-        (geary.archetypeProvider.rootArchetype.type in EventListener.event.family) shouldBe true
-        geary.archetypeProvider.rootArchetype.eventHandlers.map { it.parentListener } shouldContain EventListener
+        (archetypes.archetypeProvider.rootArchetype.type in EventListener.event.family) shouldBe true
+        archetypes.archetypeProvider.rootArchetype.eventHandlers.map { it.parentListener } shouldContain EventListener
         entity {
             set(TestComponent())
         }.callEvent()

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/RelationMatchingSystemTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/systems/RelationMatchingSystemTest.kt
@@ -6,6 +6,8 @@ import com.mineinabyss.geary.helpers.contains
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.helpers.getArchetype
 import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.archetypes
+import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.systems.accessors.TargetScope
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-8.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Providers!
- Added provider classes that define how the main geary module should be added. These follow a similar pattern to addons and let users install a module more easily, as well as modify it by passing a different module object.
- Create provider for archetype engine, as well as one for testing that doesn't start ticking the engine
- Add option to not reuse IDs on entity removal (makes testing easier until we have a better solution)

## Fixes and cleanup
- Remove unnecessary DI calls
- Cleanup test classes to use the test module
- Fix autoscanners not converting strings to classes without classloader
- Fix some gradle modules not applying the serialization plugin