### PR TITLE
Archetype cleanup, Prefab addon improvements

### DIFF
--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/PrefabLoader.kt
@@ -3,15 +3,13 @@ package com.mineinabyss.geary.prefabs
 import co.touchlab.kermit.Severity
 import com.benasher44.uuid.Uuid
 import com.mineinabyss.geary.components.relations.NoInherit
-import com.mineinabyss.geary.datatypes.Component
 import com.mineinabyss.geary.datatypes.Entity
 import com.mineinabyss.geary.helpers.entity
 import com.mineinabyss.geary.modules.geary
 import com.mineinabyss.geary.prefabs.configuration.components.Prefab
 import com.mineinabyss.geary.prefabs.helpers.inheritPrefabs
+import com.mineinabyss.geary.prefabs.serializers.ComponentListAsMapSerializer
 import com.mineinabyss.geary.serialization.dsl.serializableComponents
-import kotlinx.serialization.PolymorphicSerializer
-import kotlinx.serialization.builtins.ListSerializer
 import okio.Path
 
 class PrefabLoader {
@@ -60,7 +58,7 @@ class PrefabLoader {
     /** Registers an entity with components defined in a [path], adding a [Prefab] component. */
     fun loadFromPath(namespace: String, path: Path, writeTo: Entity? = null): Result<Entity> {
         return runCatching {
-            val serializer = ListSerializer(PolymorphicSerializer(Component::class))
+            val serializer = ComponentListAsMapSerializer()
             val ext = path.name.substringAfterLast('.')
             val decoded = formats[ext]?.decodeFromFile(serializer, path)
                 ?: throw IllegalArgumentException("Unknown file format $ext")

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/serializers/ComponentListAsMapSerializer.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/serializers/ComponentListAsMapSerializer.kt
@@ -4,6 +4,7 @@ import com.mineinabyss.geary.datatypes.GearyComponent
 import com.mineinabyss.geary.serialization.dsl.serializableComponents
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.PolymorphicKind
@@ -37,7 +38,8 @@ class ComponentListAsMapSerializer : KSerializer<List<GearyComponent>> {
         get() = MapSerializer(keySerializer, valueSerializer).descriptor
 
     override fun deserialize(decoder: Decoder): List<GearyComponent> {
-        val components = mutableSetOf<GearyComponent>()
+        val namespaces = mutableListOf<String>()
+        val components = mutableListOf<GearyComponent>()
         val compositeDecoder = decoder.beginStructure(descriptor)
         while (true) {
             val index = compositeDecoder.decodeElementIndex(descriptor)
@@ -45,17 +47,28 @@ class ComponentListAsMapSerializer : KSerializer<List<GearyComponent>> {
 
             val startIndex = components.size * 2
             val key: String = compositeDecoder.decodeSerializableElement(descriptor, startIndex + index, keySerializer)
-            val foundValueSerializer =
-                serializableComponents.serializers.getSerializerFor(key, GearyComponent::class) as? KSerializer<Any>
-                    ?: error("No component serializer registered for $key")
-            val newDescriptor = MapSerializer(keySerializer, foundValueSerializer).descriptor
-            val newIndex = compositeDecoder.decodeElementIndex(newDescriptor)
-            val decodedValue = compositeDecoder.decodeSerializableElement<Any>(
-                descriptor = newDescriptor,
-                index = newIndex,
-                deserializer = foundValueSerializer,
-            )
-            components += decodedValue
+            when (key) {
+                "namespaces" -> {
+                    val valueSerializer = ListSerializer(String.serializer())
+                    val newIndex =
+                        compositeDecoder.decodeElementIndex(MapSerializer(keySerializer, valueSerializer).descriptor)
+                    val namespacesList = compositeDecoder.decodeSerializableElement(descriptor, newIndex, valueSerializer)
+                    namespaces.addAll(namespacesList)
+                }
+                else -> {
+                    val foundValueSerializer =
+                        serializableComponents.serializers.getSerializerFor(key, GearyComponent::class, namespaces) as? KSerializer<Any>
+                            ?: error("No component serializer registered for $key")
+                    val newDescriptor = MapSerializer(keySerializer, foundValueSerializer).descriptor
+                    val newIndex = compositeDecoder.decodeElementIndex(newDescriptor)
+                    val decodedValue = compositeDecoder.decodeSerializableElement<Any>(
+                        descriptor = newDescriptor,
+                        index = newIndex,
+                        deserializer = foundValueSerializer,
+                    )
+                    components += decodedValue
+                }
+            }
         }
         compositeDecoder.endStructure(descriptor)
         return components.toList()

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/serializers/ComponentListAsMapSerializer.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/serializers/ComponentListAsMapSerializer.kt
@@ -1,0 +1,67 @@
+package com.mineinabyss.geary.prefabs.serializers
+
+import com.mineinabyss.geary.datatypes.GearyComponent
+import com.mineinabyss.geary.serialization.dsl.serializableComponents
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.descriptors.PolymorphicKind
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildSerialDescriptor
+import kotlinx.serialization.encoding.CompositeDecoder
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+
+class GearyComponentSerializer : KSerializer<GearyComponent> {
+    @OptIn(InternalSerializationApi::class)
+    override val descriptor: SerialDescriptor =
+        buildSerialDescriptor("GearyComponentSerializer", PolymorphicKind.SEALED)
+
+    override fun deserialize(decoder: Decoder): GearyComponent {
+        TODO("Not yet implemented")
+    }
+
+    override fun serialize(encoder: Encoder, value: GearyComponent) {
+        TODO("Not yet implemented")
+    }
+
+}
+
+class ComponentListAsMapSerializer : KSerializer<List<GearyComponent>> {
+    val keySerializer = String.serializer()
+    val valueSerializer = GearyComponentSerializer()
+
+    override val descriptor: SerialDescriptor
+        get() = MapSerializer(keySerializer, valueSerializer).descriptor
+
+    override fun deserialize(decoder: Decoder): List<GearyComponent> {
+        val components = mutableSetOf<GearyComponent>()
+        val compositeDecoder = decoder.beginStructure(descriptor)
+        while (true) {
+            val index = compositeDecoder.decodeElementIndex(descriptor)
+            if (index == CompositeDecoder.DECODE_DONE) break
+
+            val startIndex = components.size * 2
+            val key: String = compositeDecoder.decodeSerializableElement(descriptor, startIndex + index, keySerializer)
+            val foundValueSerializer =
+                serializableComponents.serializers.getSerializerFor(key, GearyComponent::class) as? KSerializer<Any>
+                    ?: error("No component serializer registered for $key")
+            val newDescriptor = MapSerializer(keySerializer, foundValueSerializer).descriptor
+            val newIndex = compositeDecoder.decodeElementIndex(newDescriptor)
+            val decodedValue = compositeDecoder.decodeSerializableElement<Any>(
+                descriptor = newDescriptor,
+                index = newIndex,
+                deserializer = foundValueSerializer,
+            )
+            components += decodedValue
+        }
+        compositeDecoder.endStructure(descriptor)
+        return components.toList()
+    }
+
+    override fun serialize(encoder: Encoder, value: List<GearyComponent>) {
+        TODO("Not implemented")
+    }
+}

--- a/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/ComponentSerializers.kt
+++ b/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/ComponentSerializers.kt
@@ -13,7 +13,8 @@ interface ComponentSerializers {
 
     fun <T : Component> getSerializerFor(
         key: String,
-        baseClass: KClass<in T>
+        baseClass: KClass<in T>,
+        namespaces: List<String> = emptyList()
     ): DeserializationStrategy<T>?
 
     fun <T : Component> getSerializerFor(kClass: KClass<in T>): DeserializationStrategy<out T>?

--- a/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/ComponentSerializers.kt
+++ b/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/ComponentSerializers.kt
@@ -14,7 +14,7 @@ interface ComponentSerializers {
     fun <T : Component> getSerializerFor(
         key: String,
         baseClass: KClass<in T>
-    ): DeserializationStrategy<out T>?
+    ): DeserializationStrategy<T>?
 
     fun <T : Component> getSerializerFor(kClass: KClass<in T>): DeserializationStrategy<out T>?
     fun getSerialNameFor(kClass: KClass<out Component>): String?

--- a/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/SerializersByMap.kt
+++ b/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/SerializersByMap.kt
@@ -22,7 +22,7 @@ class SerializersByMap(
         key: String,
         baseClass: KClass<in T>
     ): DeserializationStrategy<out T>? =
-        module.getPolymorphic(baseClass = baseClass, serializedClassName = key)
+        module.getPolymorphic(baseClass = baseClass, serializedClassName = key.prefixNamespaceIfNotPrefixed())
 
     override fun <T : Component> getSerializerFor(kClass: KClass<in T>): DeserializationStrategy<out T>? {
         val serialName = getSerialNameFor(kClass) ?: return null
@@ -32,4 +32,9 @@ class SerializersByMap(
 
     override fun getSerialNameFor(kClass: KClass<out Component>): String? =
         component2serialName[kClass]
+
+    private fun String.prefixNamespaceIfNotPrefixed(): String =
+        if (!contains(":"))
+            "geary:${this}"
+        else this
 }

--- a/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/SerializersByMap.kt
+++ b/addons/geary-serialization/src/commonMain/kotlin/com/mineinabyss/geary/serialization/SerializersByMap.kt
@@ -20,9 +20,16 @@ class SerializersByMap(
 
     override fun <T : Component> getSerializerFor(
         key: String,
-        baseClass: KClass<in T>
-    ): DeserializationStrategy<out T>? =
-        module.getPolymorphic(baseClass = baseClass, serializedClassName = key.prefixNamespaceIfNotPrefixed())
+        baseClass: KClass<in T>,
+        namespaces: List<String>,
+    ): DeserializationStrategy<T>? =
+        if (key.hasNamespace())
+            module.getPolymorphic(baseClass = baseClass, serializedClassName = key)
+        else {
+            namespaces.firstNotNullOfOrNull { namespace ->
+                module.getPolymorphic(baseClass = baseClass, serializedClassName = "$namespace:$key")
+            } ?: error("No serializer found for $key in any of the namespaces $namespaces")
+        }
 
     override fun <T : Component> getSerializerFor(kClass: KClass<in T>): DeserializationStrategy<out T>? {
         val serialName = getSerialNameFor(kClass) ?: return null
@@ -33,8 +40,9 @@ class SerializersByMap(
     override fun getSerialNameFor(kClass: KClass<out Component>): String? =
         component2serialName[kClass]
 
+    private fun String.hasNamespace(): Boolean = contains(":")
     private fun String.prefixNamespaceIfNotPrefixed(): String =
-        if (!contains(":"))
+        if (!hasNamespace())
             "geary:${this}"
         else this
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/KeepArchetype.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/KeepArchetype.kt
@@ -1,0 +1,7 @@
+package com.mineinabyss.geary.components
+
+/**
+ * An entity's archetype with this component may stay even if empty.
+ * Useful for entities that are created and removed often, ex events.
+ */
+sealed class KeepArchetype

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/Entity.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/Entity.kt
@@ -1,7 +1,9 @@
 package com.mineinabyss.geary.datatypes
 
 import com.mineinabyss.geary.annotations.optin.DangerousComponentOperation
+import com.mineinabyss.geary.components.RequestCheck
 import com.mineinabyss.geary.components.events.AddedComponent
+import com.mineinabyss.geary.components.events.FailedCheck
 import com.mineinabyss.geary.components.relations.InstanceOf
 import com.mineinabyss.geary.components.relations.Persists
 import com.mineinabyss.geary.datatypes.family.family
@@ -320,6 +322,23 @@ value class Entity(val id: EntityId) {
         init(event)
         callEvent(event, source)
         result(event)
+    }
+
+    fun callCheck(
+        source: Entity? = null,
+    ): Boolean {
+        return callEvent({
+            add<RequestCheck>()
+        }, source) { !it.has<FailedCheck>()}
+    }
+    inline fun callCheck(
+        crossinline init: Entity.() -> Unit,
+        source: Entity? = null,
+    ): Boolean {
+        return callEvent({
+            init()
+            add<RequestCheck>()
+        }, source) { it.has<FailedCheck>()}
     }
 
     /** Calls an event using a specific [entity][event] on this entity. */

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
@@ -10,9 +10,15 @@ expect class CompId2ArchetypeMap() {
     operator fun get(id: GearyComponentId): Archetype?
     operator fun set(id: GearyComponentId, archetype: Archetype)
 
+    fun entries(): Set<Map.Entry<ULong, Archetype>>
+
+    fun remove(id: GearyComponentId)
+
     operator fun contains(id: GearyComponentId): Boolean
 
     fun getOrSet(id: GearyComponentId, put: () -> Archetype): Archetype
+
+    val size: Int
 }
 
 class CompId2ArchetypeMapViaMutableMap {
@@ -21,6 +27,14 @@ class CompId2ArchetypeMapViaMutableMap {
     operator fun set(id: GearyComponentId, archetype: Archetype) {
         inner[id] = archetype
     }
+
+    fun entries(): Set<Map.Entry<ULong, Archetype>> = inner.entries
+
+    fun remove(id: GearyComponentId) {
+        inner.remove(id)
+    }
+
+    val size: Int get() = inner.size
 
     operator fun contains(id: GearyComponentId): Boolean = inner.containsKey(id)
 

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
@@ -12,6 +12,8 @@ expect class CompId2ArchetypeMap() {
 
     fun entries(): Set<Map.Entry<ULong, Archetype>>
 
+    fun clear()
+
     fun remove(id: GearyComponentId)
 
     operator fun contains(id: GearyComponentId): Boolean
@@ -32,6 +34,10 @@ class CompId2ArchetypeMapViaMutableMap {
 
     fun remove(id: GearyComponentId) {
         inner.remove(id)
+    }
+
+    fun clear() {
+        inner.clear()
     }
 
     val size: Int get() = inner.size

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/Family2ObjectArrayMap.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/datatypes/maps/Family2ObjectArrayMap.kt
@@ -9,7 +9,10 @@ import com.mineinabyss.geary.modules.geary
 /**
  * A map of [ComponentId]s to Arrays of objects with the ability to make fast queries based on component IDs.
  */
-internal class Family2ObjectArrayMap<T> {
+internal class Family2ObjectArrayMap<T>(
+    val getIndex: ((T) -> Int)? = null,
+    val setIndex: ((T, Int) -> Unit)? = null
+) {
     private val _elements = mutableListOf<T>()
     private val elementTypes = mutableListOf<EntityType>()
 
@@ -48,6 +51,7 @@ internal class Family2ObjectArrayMap<T> {
             }
             set(id)
         }
+        setIndex?.invoke(element, index)
     }
 
     private fun clearBits(type: EntityType, index: Int) {
@@ -65,7 +69,7 @@ internal class Family2ObjectArrayMap<T> {
     }
 
     internal fun remove(element: T) {
-        val index = _elements.indexOf(element)
+        val index = getIndex?.invoke(element) ?: _elements.indexOf(element)
          // Clear data for current element
         val type = elementTypes[index]
 

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Components.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Components.kt
@@ -1,6 +1,7 @@
 package com.mineinabyss.geary.engine
 
 import com.mineinabyss.geary.components.CouldHaveChildren
+import com.mineinabyss.geary.components.KeepArchetype
 import com.mineinabyss.geary.components.events.*
 import com.mineinabyss.geary.components.relations.ChildOf
 import com.mineinabyss.geary.components.relations.InstanceOf
@@ -19,4 +20,5 @@ class Components {
     val entityRemoved = componentId<EntityRemoved>()
     val childOf = componentId<ChildOf>()
     val instanceOf = componentId<InstanceOf>()
+    val keepArchetype = componentId<KeepArchetype>()
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Pipeline.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/Pipeline.kt
@@ -12,7 +12,7 @@ interface Pipeline {
     /** Adds a [system] to the engine, which will be ticked appropriately by the engine. */
     fun addSystem(system: System)
 
-    fun addSystems(vararg system: System)
+    fun addSystems(vararg systems: System)
 
     /** Gets all registered systems in the order they should be executed during an engine tick. */
     fun getRepeatingInExecutionOrder(): Iterable<RepeatingSystem>

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/Archetype.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/Archetype.kt
@@ -325,6 +325,10 @@ class Archetype internal constructor(
                 archetype.componentAddEdges.remove(id)
                 archetype.unregisterIfEmpty()
             }
+            componentRemoveEdges.clear()
+            targetListeners.clear()
+            sourceListeners.clear()
+            eventListeners.clear()
         }
     }
 

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeProvider.kt
@@ -4,7 +4,6 @@ import com.mineinabyss.geary.datatypes.EntityType
 
 interface ArchetypeProvider {
     val rootArchetype: Archetype
-    val count: Int
 
     fun getArchetype(entityType: EntityType): Archetype
 }

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeQueryManager.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/ArchetypeQueryManager.kt
@@ -17,7 +17,10 @@ class ArchetypeQueryManager : QueryManager {
     private val targetListeners = mutableListOf<Listener>()
     private val eventListeners = mutableListOf<Listener>()
 
-    private val archetypes = Family2ObjectArrayMap<Archetype>()
+    private val archetypes = Family2ObjectArrayMap<Archetype>(
+        getIndex = { it.id },
+        setIndex = { it, index -> it.id = index }
+    )
 
     val archetypeRegistryLock = SynchronizedObject()
 

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/SimpleArchetypeProvider.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/engine/archetypes/SimpleArchetypeProvider.kt
@@ -14,15 +14,13 @@ class SimpleArchetypeProvider : ArchetypeProvider {
             queryManager.registerArchetype(it)
         }
     }
-    override val count: Int get() = trackedArchetypes.size
 
-    private val trackedArchetypes by lazy { mutableListOf(rootArchetype) }
     private val archetypeWriteLock = SynchronizedObject()
 
 
     private fun createArchetype(prevNode: Archetype, componentEdge: ComponentId): Archetype {
-        val arc = Archetype(prevNode.type.plus(componentEdge), trackedArchetypes.size)
-            .also { trackedArchetypes += it }
+        val arc = Archetype(prevNode.type.plus(componentEdge), queryManager.archetypeCount)
+
         arc.componentRemoveEdges[componentEdge] = prevNode
         prevNode.componentAddEdges[componentEdge] = arc
         queryManager.registerArchetype(arc)

--- a/geary-core/src/jvmMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
+++ b/geary-core/src/jvmMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
@@ -11,6 +11,14 @@ actual class CompId2ArchetypeMap {
         inner[id.toLong()] = archetype
     }
 
+    actual fun remove(id: GearyComponentId) {
+        inner.remove(id.toLong())
+    }
+
+    actual fun entries(): Set<Map.Entry<ULong, Archetype>> = inner.mapKeys { it.key.toULong() }.entries
+
+    actual val size: Int get() = inner.size
+
     actual operator fun contains(id: GearyComponentId): Boolean = inner.containsKey(id.toLong())
 
     actual inline fun getOrSet(id: GearyComponentId, put: () -> Archetype): Archetype {

--- a/geary-core/src/jvmMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
+++ b/geary-core/src/jvmMain/kotlin/com/mineinabyss/geary/datatypes/maps/CompId2ArchetypeMap.kt
@@ -15,6 +15,10 @@ actual class CompId2ArchetypeMap {
         inner.remove(id.toLong())
     }
 
+    actual fun clear() {
+        inner.clear()
+    }
+
     actual fun entries(): Set<Map.Entry<ULong, Archetype>> = inner.mapKeys { it.key.toULong() }.entries
 
     actual val size: Int get() = inner.size

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/Family2ObjectArrayMapTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/Family2ObjectArrayMapTest.kt
@@ -1,0 +1,48 @@
+package com.mineinabyss.geary.datatypes
+
+import com.mineinabyss.geary.datatypes.family.family
+import com.mineinabyss.geary.datatypes.maps.Family2ObjectArrayMap
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import org.junit.jupiter.api.Test
+
+class Family2ObjectArrayMapTest {
+    @Test
+    fun addAndRemoveOne() {
+        val familyMap = Family2ObjectArrayMap<String>()
+        familyMap.add("a", EntityType(ulongArrayOf(1uL, 2uL, 3uL)))
+        familyMap.match(family { has(1uL) }) shouldContainExactly listOf("hello")
+        familyMap.remove("a")
+        familyMap.match(family { has(1uL) }).shouldBeEmpty()
+    }
+
+
+    @Test
+    fun addAndRemoveReplacingWithOther() {
+        val familyMap = Family2ObjectArrayMap<String>()
+        familyMap.add("a", EntityType(ulongArrayOf(1uL, 2uL, 3uL)))
+        familyMap.add("b", EntityType(ulongArrayOf(1uL, 3uL)))
+        familyMap.match(family { has(1uL) }).shouldContainExactly("a", "b")
+        familyMap.remove("a")
+        familyMap.match(family {
+            has(1uL)
+        }).shouldContainExactly("b")
+        familyMap.match(family {
+            has(1uL)
+            has(2uL)
+        }).shouldContainExactly()
+    }
+
+    @Test
+    fun removeLastInArray() {
+        val familyMap = Family2ObjectArrayMap<String>()
+        familyMap.add("a", EntityType(ulongArrayOf(1uL, 2uL, 3uL)))
+        familyMap.add("b", EntityType(ulongArrayOf(1uL, 3uL)))
+        familyMap.match(family { has(1uL) }).shouldContainExactly("a", "b")
+        familyMap.remove("a")
+        familyMap.remove("b")
+        familyMap.match(family {
+            has(1uL)
+        }).shouldBeEmpty()
+    }
+}

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/Family2ObjectArrayMapTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/datatypes/Family2ObjectArrayMapTest.kt
@@ -11,7 +11,7 @@ class Family2ObjectArrayMapTest {
     fun addAndRemoveOne() {
         val familyMap = Family2ObjectArrayMap<String>()
         familyMap.add("a", EntityType(ulongArrayOf(1uL, 2uL, 3uL)))
-        familyMap.match(family { has(1uL) }) shouldContainExactly listOf("hello")
+        familyMap.match(family { has(1uL) }) shouldContainExactly listOf("a")
         familyMap.remove("a")
         familyMap.match(family { has(1uL) }).shouldBeEmpty()
     }

--- a/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/events/CheckingListenerTest.kt
+++ b/geary-core/src/jvmTest/kotlin/com/mineinabyss/geary/events/CheckingListenerTest.kt
@@ -1,0 +1,39 @@
+package com.mineinabyss.geary.events
+
+import com.mineinabyss.geary.datatypes.Records
+import com.mineinabyss.geary.helpers.entity
+import com.mineinabyss.geary.helpers.tests.GearyTest
+import com.mineinabyss.geary.modules.geary
+import com.mineinabyss.geary.systems.accessors.Pointers
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class CheckingListenerTest : GearyTest() {
+    class MyEvent()
+
+    class MyListener : CheckingListener() {
+        var called = 0
+
+        val Records.data by get<Int>().on(target)
+
+        override fun Pointers.check(): Boolean {
+            return data > 10
+        }
+    }
+
+    @Test
+    fun `simple set listener`() {
+        val listener = MyListener()
+        geary.pipeline.addSystem(listener)
+
+        val entityFail = entity {
+            set(1)
+        }
+        val entityPass = entity {
+            set(20)
+        }
+
+        entityFail.callCheck() shouldBe false
+        entityPass.callCheck() shouldBe true
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.mineinabyss
-version=0.23
+version=0.24
 # Workaround for dokka builds failing on CI, see https://github.com/Kotlin/dokka/issues/1405
 #org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
 idofrontVersion=0.18.26


### PR DESCRIPTION
- Remove empty archetypes on component remove to fix buildup over time
  - Option to persist archetypes that may be recreated often ex. for events
- Use new map serializer for prefab files
- When reloading prefabs, keep PrefabKey even on a failed reload to allow subsequent reloads