### PR TITLE
Add support for subkeys in prefab config

### DIFF
--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/configuration/components/CopyToInstances.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/configuration/components/CopyToInstances.kt
@@ -8,8 +8,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * > geary:copy_to_instances
- *
  * A component prefabs may use to specify a list of components which should be copied to instances of itself.
  *
  * These components are not active on the prefab itself and will be instantiated for every new instance of this class.
@@ -17,7 +15,7 @@ import kotlinx.serialization.Serializable
  * in the Engine.
  */
 @Serializable
-@SerialName("geary:copy_to_instances")
+@SerialName("geary:copyToInstances")
 data class CopyToInstances(
     private val temporary: Set<@Polymorphic Component> = setOf(),
     private val persisting: Set<@Polymorphic Component> = setOf(),

--- a/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/serializers/PrefabKeySerializer.kt
+++ b/addons/geary-prefabs/src/commonMain/kotlin/com/mineinabyss/geary/prefabs/serializers/PrefabKeySerializer.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 
 object PrefabKeySerializer : KSerializer<PrefabKey> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("geary:prefab_key", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("geary:prefabKey", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): PrefabKey {
         return PrefabKey.of(decoder.decodeString())

--- a/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/ComponentInfo.kt
+++ b/geary-core/src/commonMain/kotlin/com/mineinabyss/geary/components/ComponentInfo.kt
@@ -8,7 +8,7 @@ import kotlin.reflect.KClassifier
  * Represents the [class][kClass] a component entity is responsible for.
  */
 @Serializable
-@SerialName("geary:component_info")
+@SerialName("geary:componentInfo")
 data class ComponentInfo(
     val kClass: KClassifier
 )


### PR DESCRIPTION
ex:
```yaml
set.*:
    entityType: ...
    size: ...
```